### PR TITLE
feat: ensure no results return from non-user org

### DIFF
--- a/app/access/tests/functional/team/test_team_permission_viewset.py
+++ b/app/access/tests/functional/team/test_team_permission_viewset.py
@@ -44,10 +44,17 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         self.item = self.model.objects.create(
             organization=organization,
             name = 'teamone'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization=different_organization,
+            name = 'teamtwo'
         )
 
 

--- a/app/access/tests/functional/team_user/test_team_user_permission_viewset.py
+++ b/app/access/tests/functional/team_user/test_team_user_permission_viewset.py
@@ -43,6 +43,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -57,7 +59,14 @@ class ViewSetBase:
             organization = organization,
         )
 
+        view_team_b = Team.objects.create(
+            team_name = 'view_team',
+            organization = different_organization,
+        )
+
         view_team.permissions.set([view_permissions])
+
+        view_team_b.permissions.set([view_permissions])
 
 
 
@@ -116,10 +125,17 @@ class ViewSetBase:
 
         self.view_user = User.objects.create_user(username="test_user_view", password="password")
 
+        self.view_user_b = User.objects.create_user(username="test_user_view_b", password="password")
+
 
         self.item = TeamUsers.objects.create(
             team = view_team,
             user = self.view_user
+        )
+
+        self.other_org_item = TeamUsers.objects.create(
+            team = view_team_b,
+            user = self.view_user_b
         )
 
         self.url_view_kwargs = {'organization_id': self.organization.id, 'team_id': view_team.id, 'pk': self.item.id}
@@ -178,7 +194,11 @@ class TeamUserPermissionsAPI(
     TestCase
 ):
 
-    pass
+
+    def test_returned_results_only_user_orgs(self):
+        """This test is not applicable for team_user as users are not tenancy objects
+        """
+        pass
 
 
 

--- a/app/api/tests/abstract/api_permissions_viewset.py
+++ b/app/api/tests/abstract/api_permissions_viewset.py
@@ -85,6 +85,50 @@ class APIPermissionView:
 
 
 
+    def test_returned_results_only_user_orgs(self):
+        """Returned results check
+
+        Ensure that a query to the viewset endpoint does not return
+        items that are not part of the users organizations.
+        """
+
+
+        # Ensure the other org item exists, without test not able to function
+        print('Check that the different organization item has been defined')
+        assert hasattr(self, 'other_org_item')
+
+        # ensure that the variables for the two orgs are different orgs
+        print('checking that the different and user oganizations are different')
+        assert self.different_organization.id != self.organization.id
+
+
+        client = Client()
+
+        if self.url_kwargs:
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+
+        else:
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+
+
+        client.force_login(self.view_user)
+        response = client.get(url)
+
+        contains_different_org: bool = False
+
+        for item in response.data['results']:
+
+            if int(item['organization']['id']) != self.organization.id:
+
+                contains_different_org = True
+
+        assert not contains_different_org
+
+
+
+
 class APIPermissionAdd:
 
 
@@ -211,7 +255,6 @@ class APIPermissionAdd:
         response = client.post(url, data=self.add_data)
 
         assert response.status_code == 201
-
 
 
 class APIPermissionChange:

--- a/app/assistance/tests/functional/knowledge_base/test_knowledge_base_viewset.py
+++ b/app/assistance/tests/functional/knowledge_base/test_knowledge_base_viewset.py
@@ -46,6 +46,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
 
         self.url_kwargs = {}
@@ -122,6 +124,7 @@ class ViewSetBase:
 
 
         self.view_user = User.objects.create_user(username="test_user_view", password="password")
+        self.view_user_b = User.objects.create_user(username="test_user_view_b", password="password")
         teamuser = TeamUsers.objects.create(
             team = view_team,
             user = self.view_user
@@ -133,6 +136,13 @@ class ViewSetBase:
             title = 'one',
             content = 'some text for body',
             target_user = self.view_user
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            title = 'two',
+            content = 'some text for body',
+            target_user = self.view_user_b
         )
 
 

--- a/app/assistance/tests/functional/knowledge_base_category/test_knowledge_base_category_viewset.py
+++ b/app/assistance/tests/functional/knowledge_base_category/test_knowledge_base_category_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
 
         # self.url_kwargs = {}
@@ -118,6 +120,7 @@ class ViewSetBase:
 
 
         self.view_user = User.objects.create_user(username="test_user_view", password="password")
+        self.view_user_b = User.objects.create_user(username="test_user_view_b", password="password")
         teamuser = TeamUsers.objects.create(
             team = view_team,
             user = self.view_user
@@ -128,6 +131,12 @@ class ViewSetBase:
             organization = self.organization,
             name = 'one',
             target_user = self.view_user
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            name = 'two',
+            target_user = self.view_user_b
         )
 
 

--- a/app/config_management/tests/functional/config_groups/test_config_groups_notes_viewset.py
+++ b/app/config_management/tests/functional/config_groups/test_config_groups_notes_viewset.py
@@ -47,6 +47,13 @@ class NotePermissionsAPI(
             config_group = self.note_item
         )
 
+        self.other_org_item = Notes.objects.create(
+            organization = self.different_organization,
+            note = 'b note',
+            usercreated = self.view_user,
+            config_group = self.note_item
+        )
+
 
         self.url_kwargs = {'config_group_id': self.note_item.id}
 

--- a/app/config_management/tests/functional/config_groups/test_config_groups_viewset.py
+++ b/app/config_management/tests/functional/config_groups/test_config_groups_viewset.py
@@ -46,6 +46,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
 
         # self.url_kwargs = {}
@@ -131,6 +133,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            name = 'two'
         )
 
 

--- a/app/config_management/tests/functional/config_groups_software/test_config_groups_software_viewset.py
+++ b/app/config_management/tests/functional/config_groups_software/test_config_groups_software_viewset.py
@@ -46,6 +46,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
 
 
@@ -131,6 +133,11 @@ class ViewSetBase:
             name = 'one'
         )
 
+        self.config_group_b = ConfigGroups.objects.create(
+            organization = self.different_organization,
+            name = 'two'
+        )
+
         self.url_kwargs = { 'config_group_id': self.config_group.id }
 
         self.software = Software.objects.create(
@@ -160,6 +167,13 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             config_group = self.config_group,
+            software = self.software,
+            version = self.software_version
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            config_group = self.config_group_b,
             software = self.software,
             version = self.software_version
         )

--- a/app/core/serializers/ticket_category.py
+++ b/app/core/serializers/ticket_category.py
@@ -83,7 +83,7 @@ class TicketCategoryModelSerializer(
             ):
 
                 self.fields['parent'].queryset = self.fields['parent'].queryset.exclude(
-                    id=self.instance.pk
+                    id = int(self._context['view'].kwargs['pk'])
                 )
 
 

--- a/app/core/tests/abstract/test_notes_viewset.py
+++ b/app/core/tests/abstract/test_notes_viewset.py
@@ -45,6 +45,8 @@ class NoteViewSetCommon(
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + Notes._meta.model_name,

--- a/app/core/tests/abstract/test_ticket_viewset.py
+++ b/app/core/tests/abstract/test_ticket_viewset.py
@@ -53,6 +53,8 @@ class TicketViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_ticket_' + self.ticket_type,
@@ -164,6 +166,13 @@ class TicketViewSetBase:
             user = self.view_user
         )
 
+        user_settings = UserSettings.objects.get(user=self.view_user)
+
+        user_settings.default_organization = self.organization
+
+        user_settings.save()
+
+
 
         self.project = Project.objects.create(
             organization = self.organization,
@@ -174,6 +183,16 @@ class TicketViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             title = 'one',
+            description = 'some text for body',
+            opened_by = self.view_user,
+            ticket_type = self.ticket_type_enum,
+            status = Ticket.TicketStatus.All.NEW,
+            project = self.project,
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            title = 'two',
             description = 'some text for body',
             opened_by = self.view_user,
             ticket_type = self.ticket_type_enum,

--- a/app/core/tests/functional/manufacturer/test_manufacturer_viewset.py
+++ b/app/core/tests/functional/manufacturer/test_manufacturer_viewset.py
@@ -46,6 +46,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
 
         # self.url_kwargs = {}
@@ -131,6 +133,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            name = 'two'
         )
 
 

--- a/app/core/tests/functional/related_ticket/test_related_ticket_viewset.py
+++ b/app/core/tests/functional/related_ticket/test_related_ticket_viewset.py
@@ -263,3 +263,13 @@ class RelatedTicketsPermissionsAPI(
         response = client.put(url, data=self.change_data, content_type='application/json')
 
         assert response.status_code == 405
+
+
+    def test_returned_results_only_user_orgs(self):
+        """Test not required
+
+        this test is not required as a related ticket obtains it's
+        organization from the ticket.
+        """
+
+        pass

--- a/app/core/tests/functional/test_history/test_history_viewset.py
+++ b/app/core/tests/functional/test_history/test_history_viewset.py
@@ -315,3 +315,14 @@ class HistoryPermissionsAPI(APIPermissionView, TestCase):
         response = client.delete(url, data=self.delete_data)
 
         assert response.status_code == 405
+
+
+    def test_returned_results_only_user_orgs(self):
+        """Test not required
+
+        this test is not required as a history item obtains it's
+        organization from the object changed.
+        """
+
+        pass
+

--- a/app/core/tests/functional/test_task_result/test_task_result_viewset.py
+++ b/app/core/tests/functional/test_task_result/test_task_result_viewset.py
@@ -520,3 +520,14 @@ class TaskResultPermissionsAPI(
         response = client.get(url)
 
         assert response.status_code == 200
+
+
+    def test_returned_results_only_user_orgs(self):
+        """Test not required
+
+        this test is not required as a task result
+        is not a tenancy object that a user has any CRUD
+        op to.
+        """
+
+        pass

--- a/app/core/tests/functional/ticket_category/test_ticket_category_viewset.py
+++ b/app/core/tests/functional/ticket_category/test_ticket_category_viewset.py
@@ -46,6 +46,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -127,6 +129,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            name = 'two'
         )
 
 

--- a/app/core/tests/functional/ticket_category/test_ticket_category_viewset.py
+++ b/app/core/tests/functional/ticket_category/test_ticket_category_viewset.py
@@ -198,7 +198,7 @@ class TicketCategoryPermissionsAPI(
 
 class TicketCategoryViewSet(
     ViewSetBase,
-    APIPermissions,
+    SerializersTestCases,
     TestCase,
 ):
 

--- a/app/core/tests/functional/ticket_comment/test_ticket_comment_viewset.py
+++ b/app/core/tests/functional/ticket_comment/test_ticket_comment_viewset.py
@@ -228,3 +228,13 @@ class TicketCommentPermissionsAPI(
             team = different_organization_team,
             user = self.different_organization_user
         )
+
+
+    def test_returned_results_only_user_orgs(self):
+        """Test not required
+
+        this test is not required as a ticket comment obtains it's
+        organization from the ticket.
+        """
+
+        pass

--- a/app/core/tests/functional/ticket_comment_category/test_ticket_comment_category_viewset.py
+++ b/app/core/tests/functional/ticket_comment_category/test_ticket_comment_category_viewset.py
@@ -46,6 +46,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -127,6 +129,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            name = 'two'
         )
 
 

--- a/app/core/tests/functional/ticket_linked_item/test_ticket_linked_item_viewset.py
+++ b/app/core/tests/functional/ticket_linked_item/test_ticket_linked_item_viewset.py
@@ -325,6 +325,16 @@ class BaseItemTicketPermissionsAPI(
         assert response.status_code == 201
 
 
+    def test_returned_results_only_user_orgs(self):
+        """Test not required
+
+        this test is not required as a ticket linked item obtains it's
+        organization from the ticket.
+        """
+
+        pass
+
+
 
 class BaseItemTicketSerializer(
     BaseItemTicket,

--- a/app/core/viewsets/ticket.py
+++ b/app/core/viewsets/ticket.py
@@ -247,6 +247,8 @@ class TicketViewSet(ModelViewSet):
             or self.action == 'update'
         ):
 
+            organization = None
+
 
             if (
                 self.action == 'list'

--- a/app/itam/tests/functional/device/test_device_notes_viewset.py
+++ b/app/itam/tests/functional/device/test_device_notes_viewset.py
@@ -36,8 +36,13 @@ class DeviceNotePermissionsAPI(
 
 
         self.note_item = Device.objects.create(
-            organization = self.organization,
+            organization = self.different_organization,
             name = 'history-device'
+        )
+
+        self.note_item_b = Device.objects.create(
+            organization = self.organization,
+            name = 'history-device-b'
         )
 
         self.item = Notes.objects.create(
@@ -45,6 +50,13 @@ class DeviceNotePermissionsAPI(
             note = 'a note',
             usercreated = self.view_user,
             device = self.note_item
+        )
+
+        self.other_org_item = Notes.objects.create(
+            organization = self.different_organization,
+            note = 'b note',
+            usercreated = self.view_user,
+            device = self.note_item_b
         )
 
 

--- a/app/itam/tests/functional/device/test_device_notes_viewset.py
+++ b/app/itam/tests/functional/device/test_device_notes_viewset.py
@@ -36,12 +36,12 @@ class DeviceNotePermissionsAPI(
 
 
         self.note_item = Device.objects.create(
-            organization = self.different_organization,
+            organization = self.organization,
             name = 'history-device'
         )
 
         self.note_item_b = Device.objects.create(
-            organization = self.organization,
+            organization = self.different_organization,
             name = 'history-device-b'
         )
 

--- a/app/itam/tests/functional/device/test_device_viewset.py
+++ b/app/itam/tests/functional/device/test_device_viewset.py
@@ -2,7 +2,8 @@ import pytest
 
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from django.shortcuts import reverse
+from django.test import Client, TestCase
 
 from access.models import Organization, Team, TeamUsers, Permission
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
@@ -41,6 +42,8 @@ class ViewSetBase:
         self.organization = organization
 
         different_organization = Organization.objects.create(name='test_different_organization')
+
+        self.different_organization = different_organization
 
 
         view_permissions = Permission.objects.get(
@@ -125,6 +128,11 @@ class ViewSetBase:
             name = 'one-add'
         )
 
+        self.other_org_item = self.model.objects.create(
+            organization = different_organization,
+            name = 'other_item'
+        )
+
 
         self.url_view_kwargs = {'pk': self.item.id}
 
@@ -182,7 +190,6 @@ class DevicePermissionsAPI(
 ):
 
     pass
-
 
 
 class DeviceViewSet(

--- a/app/itam/tests/functional/device_model/test_device_model_viewset.py
+++ b/app/itam/tests/functional/device_model/test_device_model_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -123,6 +125,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one-add'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = different_organization,
+            name = 'two-add'
         )
 
 

--- a/app/itam/tests/functional/device_operating_system/test_device_operating_system_viewset.py
+++ b/app/itam/tests/functional/device_operating_system/test_device_operating_system_viewset.py
@@ -43,6 +43,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -164,12 +166,24 @@ class ViewSetBase:
             name = 'device-two'
         )
 
+        self.device_three = Device.objects.create(
+            organization=different_organization,
+            name = 'device-three'
+        )
+
 
         self.item = self.model.objects.create(
             organization=self.organization,
             version = '1',
             operating_system_version = self.operating_system_version,
             device = self.device
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization=different_organization,
+            version = '1',
+            operating_system_version = self.operating_system_version,
+            device = self.device_three
         )
 
 

--- a/app/itam/tests/functional/device_software/test_device_software_viewset.py
+++ b/app/itam/tests/functional/device_software/test_device_software_viewset.py
@@ -43,6 +43,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -125,6 +127,11 @@ class ViewSetBase:
             name = 'a-device'
         )
 
+        device_two = Device.objects.create(
+            organization = different_organization,
+            name = 'b-device'
+        )
+
         software = Software.objects.create(
             organization = self.organization,
             name = 'a-software'
@@ -139,6 +146,12 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             device = device,
+            software = software
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = different_organization,
+            device = device_two,
             software = software
         )
 

--- a/app/itam/tests/functional/device_type/test_device_type_viewset.py
+++ b/app/itam/tests/functional/device_type/test_device_type_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -123,6 +125,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one-add'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = different_organization,
+            name = 'two-add'
         )
 
 

--- a/app/itam/tests/functional/endpoint_operating_system_installs/test_operating_system_installs_viewset.py
+++ b/app/itam/tests/functional/endpoint_operating_system_installs/test_operating_system_installs_viewset.py
@@ -43,6 +43,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -113,6 +115,11 @@ class ViewSetBase:
             name = 'device'
         )
 
+        self.device_b = Device.objects.create(
+            organization=different_organization,
+            name = 'device-b'
+        )
+
 
         self.item = self.model.objects.create(
             organization=self.organization,
@@ -121,6 +128,15 @@ class ViewSetBase:
             device = self.device
         )
 
+        self.other_org_item = self.model.objects.create(
+            organization=different_organization,
+            version = '2',
+            operating_system_version = self.operating_system_version,
+            device = self.device_b
+        )
+
+
+        self.url_kwargs = {'operating_system_id': self.operating_system_version.operating_system.pk}
 
         self.url_view_kwargs = {'operating_system_id': self.operating_system_version.operating_system.pk, 'pk': self.item.id}
 

--- a/app/itam/tests/functional/endpoint_software_installs/test_software_installs_viewset.py
+++ b/app/itam/tests/functional/endpoint_software_installs/test_software_installs_viewset.py
@@ -43,6 +43,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -125,6 +127,11 @@ class ViewSetBase:
             name = 'a-device'
         )
 
+        device_b = Device.objects.create(
+            organization = different_organization,
+            name = 'b-device'
+        )
+
         software = Software.objects.create(
             organization = self.organization,
             name = 'a-software'
@@ -135,11 +142,22 @@ class ViewSetBase:
             name = 'b-software'
         )
 
+        software_c = Software.objects.create(
+            organization = different_organization,
+            name = 'c-software'
+        )
+
 
         self.item = self.model.objects.create(
             organization = self.organization,
             device = device,
             software = software
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = different_organization,
+            device = device_b,
+            software = software_c
         )
 
 

--- a/app/itam/tests/functional/operating_system/test_operating_system_notes_viewset.py
+++ b/app/itam/tests/functional/operating_system/test_operating_system_notes_viewset.py
@@ -40,11 +40,23 @@ class OperatingSystemNotePermissionsAPI(
             name = 'history-device'
         )
 
+        self.note_item_b = OperatingSystem.objects.create(
+            organization = self.organization,
+            name = 'history-device-b'
+        )
+
         self.item = Notes.objects.create(
             organization = self.organization,
             note = 'a note',
             usercreated = self.view_user,
             operatingsystem = self.note_item
+        )
+
+        self.other_org_item = Notes.objects.create(
+            organization = self.different_organization,
+            note = 'b note',
+            usercreated = self.view_user,
+            operatingsystem = self.note_item_b
         )
 
 

--- a/app/itam/tests/functional/operating_system/test_operating_system_viewset.py
+++ b/app/itam/tests/functional/operating_system/test_operating_system_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -123,6 +125,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one-add'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = different_organization,
+            name = 'two-add'
         )
 
 

--- a/app/itam/tests/functional/operating_system_version/test_operating_system_version_viewset.py
+++ b/app/itam/tests/functional/operating_system_version/test_operating_system_version_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -124,11 +126,22 @@ class ViewSetBase:
             name = 'one-add'
         )
 
+        os_b = OperatingSystem.objects.create(
+            organization = different_organization,
+            name = 'two-add'
+        )
+
 
         self.item = self.model.objects.create(
             organization = self.organization,
             name = '5',
             operating_system = os
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = different_organization,
+            name = '6',
+            operating_system = os_b
         )
 
 

--- a/app/itam/tests/functional/software/test_software_notes_viewset.py
+++ b/app/itam/tests/functional/software/test_software_notes_viewset.py
@@ -40,11 +40,23 @@ class SoftwareNotePermissionsAPI(
             name = 'history-device'
         )
 
+        self.note_item_b = Software.objects.create(
+            organization = self.different_organization,
+            name = 'history-device-b'
+        )
+
         self.item = Notes.objects.create(
             organization = self.organization,
             note = 'a note',
             usercreated = self.view_user,
             software = self.note_item
+        )
+
+        self.other_org_item = Notes.objects.create(
+            organization = self.different_organization,
+            note = 'b note',
+            usercreated = self.view_user,
+            software = self.note_item_b
         )
 
 

--- a/app/itam/tests/functional/software/test_software_viewset.py
+++ b/app/itam/tests/functional/software/test_software_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -123,6 +125,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one-add'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = different_organization,
+            name = 'two-add'
         )
 
 

--- a/app/itam/tests/functional/software_category/test_software_category_viewset.py
+++ b/app/itam/tests/functional/software_category/test_software_category_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -123,6 +125,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one-add'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = different_organization,
+            name = 'two-add'
         )
 
 

--- a/app/itam/tests/functional/software_version/test_software_version_viewset.py
+++ b/app/itam/tests/functional/software_version/test_software_version_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -123,10 +125,22 @@ class ViewSetBase:
                 organization = self.organization,
                 name = 'software'
             )
+
+        software_b = Software.objects.create(
+                organization = different_organization,
+                name = 'software-b'
+            )
+
         self.item = self.model.objects.create(
             organization = self.organization,
             name = '12',
             software = software
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = different_organization,
+            name = '13',
+            software = software_b
         )
 
 

--- a/app/itim/tests/functional/cluster/test_cluster_viewset.py
+++ b/app/itim/tests/functional/cluster/test_cluster_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -123,6 +125,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one-add'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            name = 'two-add'
         )
 
 

--- a/app/itim/tests/functional/cluster_types/test_cluster_type_viewset.py
+++ b/app/itim/tests/functional/cluster_types/test_cluster_type_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -123,6 +125,12 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one-add'
+        )
+
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            name = 'two-add'
         )
 
 

--- a/app/itim/tests/functional/port/test_port_viewset.py
+++ b/app/itim/tests/functional/port/test_port_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -123,6 +125,12 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             number = 80,
+            protocol = Port.Protocol.TCP
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            number = 81,
             protocol = Port.Protocol.TCP
         )
 

--- a/app/itim/tests/functional/service/test_service_notes_viewset.py
+++ b/app/itim/tests/functional/service/test_service_notes_viewset.py
@@ -47,6 +47,13 @@ class ServiceNotePermissionsAPI(
             service = self.note_item
         )
 
+        self.other_org_item = Notes.objects.create(
+            organization = self.different_organization,
+            note = 'b note',
+            usercreated = self.view_user,
+            service = self.note_item
+        )
+
 
         self.url_kwargs = {'service_id': self.note_item.id}
 

--- a/app/itim/tests/functional/service/test_service_viewset.py
+++ b/app/itim/tests/functional/service/test_service_viewset.py
@@ -44,6 +44,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -137,6 +139,13 @@ class ViewSetBase:
             name = 'os name',
             device = device,
             config_key_variable = 'value'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization=different_organization,
+            name = 'os name b',
+            device = device,
+            config_key_variable = 'values'
         )
 
         self.item.port.set([ port ])

--- a/app/project_management/tests/functional/project/test_project_viewset.py
+++ b/app/project_management/tests/functional/project/test_project_viewset.py
@@ -43,6 +43,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -147,6 +149,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one-add'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            name = 'two-add'
         )
 
 

--- a/app/project_management/tests/functional/project_milestone/test_project_milestone_viewset.py
+++ b/app/project_management/tests/functional/project_milestone/test_project_milestone_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -124,11 +126,22 @@ class ViewSetBase:
             name = 'proj milestone test'
         )
 
+        project_b = Project.objects.create(
+            organization = self.different_organization,
+            name = 'proj b milestone test'
+        )
+
 
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one-add',
             project = project
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            name = 'two-add',
+            project = project_b
         )
 
 

--- a/app/project_management/tests/functional/project_state/test_project_state_viewset.py
+++ b/app/project_management/tests/functional/project_state/test_project_state_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -123,6 +125,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one-add'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            name = 'two-add'
         )
 
 

--- a/app/project_management/tests/functional/project_type/test_project_type_viewset.py
+++ b/app/project_management/tests/functional/project_type/test_project_type_viewset.py
@@ -42,6 +42,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
         view_permissions = Permission.objects.get(
                 codename = 'view_' + self.model._meta.model_name,
@@ -123,6 +125,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one-add'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            name = 'two-add'
         )
 
 

--- a/app/settings/tests/functional/app_settings/test_app_settings_viewset.py
+++ b/app/settings/tests/functional/app_settings/test_app_settings_viewset.py
@@ -224,6 +224,14 @@ class AppSettingsPermissionsAPI(
         assert response.status_code == 405
 
 
+    def test_returned_results_only_user_orgs(self):
+        """Test not required
+
+        this test is not required as this model is not a tenancy model
+        """
+
+        pass
+
 
 class AppSettingsViewSet(
     ViewSetBase,

--- a/app/settings/tests/functional/external_links/test_external_link_viewset.py
+++ b/app/settings/tests/functional/external_links/test_external_link_viewset.py
@@ -46,6 +46,8 @@ class ViewSetBase:
 
         different_organization = Organization.objects.create(name='test_different_organization')
 
+        self.different_organization = different_organization
+
 
 
         # self.url_kwargs = {}
@@ -131,6 +133,11 @@ class ViewSetBase:
         self.item = self.model.objects.create(
             organization = self.organization,
             name = 'one'
+        )
+
+        self.other_org_item = self.model.objects.create(
+            organization = self.different_organization,
+            name = 'two'
         )
 
 

--- a/app/settings/tests/functional/user_settings/test_user_settings_viewset.py
+++ b/app/settings/tests/functional/user_settings/test_user_settings_viewset.py
@@ -249,6 +249,15 @@ class UserSettingsPermissionsAPI(
         assert response.status_code == 200
 
 
+    def test_returned_results_only_user_orgs(self):
+        """Test not required
+
+        this test is not required as this model is not a tenancy model
+        """
+
+        pass
+
+
 
 class UserSettingsViewSet(
     ViewSetBase,

--- a/docs/projects/centurion_erp/index.md
+++ b/docs/projects/centurion_erp/index.md
@@ -121,6 +121,8 @@ Below is a list of modules/features we intend to add to Centurion. To find out w
 
         - Licence Management _[see #4](https://github.com/nofusscomputing/centurion_erp/issues/4)_
 
+        - Certificate Management
+
     - IT Infrastructure Management (ITIM) _[see #61](https://github.com/nofusscomputing/centurion_erp/issues/61)_
 
         - Database Management _[see #72](https://github.com/nofusscomputing/centurion_erp/issues/72)_
@@ -135,9 +137,15 @@ Below is a list of modules/features we intend to add to Centurion. To find out w
 
             - Software _[see #3](https://github.com/nofusscomputing/centurion_erp/issues/3)_
 
+    - IT Operations
+
+        - Service level management _[see #396](https://github.com/nofusscomputing/centurion_erp/issues/396)_
+
     - Order Management _[see #94](https://github.com/nofusscomputing/centurion_erp/issues/94)_
 
         - Supplier Management _[see #123](https://github.com/nofusscomputing/centurion_erp/issues/123)_
+
+    - Service Catalog _[see #1384](https://github.com/nofusscomputing/centurion_erp/issues/384)_
 
 
 - **Planned Integrations:**


### PR DESCRIPTION
### :books: Summary
<!-- your summary here emojis ref: https://github.com/yodamad/gitlab-emoji -->



### :link: Links / References
<!-- 

    using a list as any links to other references or links as required. if relevant, describe the link/reference

    Include any issues or related merge requests. Note: dependent MR's also to be added to "Merge request dependencies"

-->

- #359


### :construction_worker: Tasks

 - [ ] Add your tasks here if required (delete)

<!-- dont remove tasks below strike through including the checkbox by enclosing in double tidle '~~' -->

- [ ] :firecracker: Contains breaking-change Any Breaking change(s)?

    _Breaking Change must also be notated in the commit that introduces it and in [Conventional Commit Format](https://www.conventionalcommits.org/en/v1.0.0/)._

    - [ ] :notebook: Release notes updated

- [ ] :blue_book: Documentation written

    _All features to be documented within the correct section(s). Administration, Development and/or User_

- [ ] :checkered_flag: Milestone assigned

- [x] :test_tube: [Unit Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

    _ensure test coverage delta is not less than zero_

- [ ] :page_facing_up: Roadmap updated
