### PR TITLE
fix(core): Ensure user cant view tickets in orgs they are not part of

### DIFF
--- a/app/access/models.py
+++ b/app/access/models.py
@@ -126,9 +126,10 @@ class TenancyManager(models.Manager):
                         user_organizations += [ team_user.team.organization.id ]
 
 
-                if len(user_organizations) > 0 and not user.is_superuser and self.model.is_global is not None:
+                # if len(user_organizations) > 0 and not user.is_superuser and self.model.is_global is not None:
+                if len(user_organizations) > 0 and not user.is_superuser:
 
-                    if self.model.is_global:
+                    if getattr(self.model, 'is_global', False) is True:
 
                         return super().get_queryset().filter(
                             models.Q(organization__in=user_organizations)

--- a/app/api/views/core/tickets.py
+++ b/app/api/views/core/tickets.py
@@ -72,7 +72,10 @@ class View(OrganizationMixin, viewsets.ModelViewSet):
         return super().get_permission_required()
 
 
-    queryset = Ticket.objects.all()
+    # queryset = Ticket.objects.all()
+    queryset = None
+
+    model = Ticket
 
 
     def get_serializer(self, *args, **kwargs):
@@ -114,32 +117,48 @@ class View(OrganizationMixin, viewsets.ModelViewSet):
 
         if self._ticket_type == 'change':
 
-            ticket_type = self.queryset.model.TicketType.CHANGE.value
+            ticket_type = self.model.TicketType.CHANGE.value
 
         elif self._ticket_type == 'incident':
 
-            ticket_type = self.queryset.model.TicketType.INCIDENT.value
+            ticket_type = self.model.TicketType.INCIDENT.value
 
         elif self._ticket_type == 'problem':
 
-            ticket_type = self.queryset.model.TicketType.PROBLEM.value
+            ticket_type = self.model.TicketType.PROBLEM.value
 
         elif self._ticket_type == 'request':
 
-            ticket_type = self.queryset.model.TicketType.REQUEST.value
+            ticket_type = self.model.TicketType.REQUEST.value
 
         elif self._ticket_type == 'project_task':
 
-            ticket_type = self.queryset.model.TicketType.REQUEST.value
+            ticket_type = self.model.TicketType.REQUEST.value
 
-            return self.queryset.filter(
-                project = self.kwargs['project_id']
-            )
+            # return self.queryset.filter(
+            #     project = self.kwargs['project_id']
+            # )
 
         else:
 
             raise ValueError('Unknown ticket type. kwarg `ticket_type` must be set')
 
-        return self.queryset.filter(
-            ticket_type = ticket_type
-        )
+
+        if not self.queryset:
+
+            queryset = Ticket.objects.all()
+
+            queryset = queryset.filter(
+                ticket_type = ticket_type
+            )
+
+            if self._ticket_type == 'project_task':
+
+                queryset = queryset.filter(
+                    project = self.kwargs['project_id']
+                )
+
+            self.queryset = queryset
+
+
+        return self.queryset

--- a/app/api/views/mixin.py
+++ b/app/api/views/mixin.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.forms import ValidationError
 
 from rest_framework import exceptions
@@ -35,7 +35,14 @@ class OrganizationPermissionAPI(DjangoObjectPermissions, OrganizationMixin):
 
             view.http_method_not_allowed(request._request)
 
-        if hasattr(view, 'queryset'):
+        if hasattr(view, 'get_queryset'):
+
+            queryset  = view.get_queryset()
+
+            self.obj = queryset.model
+
+        elif hasattr(view, 'queryset'):
+
             if view.queryset.model._meta:
                 self.obj = view.queryset.model
 
@@ -91,7 +98,13 @@ class OrganizationPermissionAPI(DjangoObjectPermissions, OrganizationMixin):
 
             if object_organization is None and 'pk' in view.kwargs:
 
-                self.obj = view.queryset.get(pk=view.kwargs['pk'])
+                try:
+
+                    self.obj = view.queryset.get(pk=view.kwargs['pk'])    # Here
+
+                except ObjectDoesNotExist:
+
+                    return False
 
 
         if obj:
@@ -115,7 +128,13 @@ class OrganizationPermissionAPI(DjangoObjectPermissions, OrganizationMixin):
 
                 if object_organization is None:
 
-                    self.obj = view.queryset.get()
+                    try:
+
+                        self.obj = view.queryset.get()
+
+                    except ObjectDoesNotExist:
+
+                        return False
 
 
         if hasattr(self, 'obj') and object_organization is None and 'pk' in view.kwargs:


### PR DESCRIPTION
### :books: Summary
<!-- your summary here emojis ref: https://github.com/yodamad/gitlab-emoji -->

Users can view tickets from orgs they are not apart of. This MR is for immediate release.

This MR is to include the reverted changes from #398.

### :link: Links / References
<!-- 

    using a list as any links to other references or links as required. if relevant, describe the link/reference

    Include any issues or related merge requests. Note: dependent MR's also to be added to "Merge request dependencies"

-->

- #398


### :construction_worker: Tasks

 - [ ] Add your tasks here if required (delete)

<!-- dont remove tasks below strike through including the checkbox by enclosing in double tidle '~~' -->

- [ ] :firecracker: Contains breaking-change Any Breaking change(s)?

    _Breaking Change must also be notated in the commit that introduces it and in [Conventional Commit Format](https://www.conventionalcommits.org/en/v1.0.0/)._

    - [ ] :notebook: Release notes updated

- [ ] :blue_book: Documentation written

    _All features to be documented within the correct section(s). Administration, Development and/or User_

- [ ] :checkered_flag: Milestone assigned

- [ ] :test_tube: [Unit Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

    _ensure test coverage delta is not less than zero_

- [ ] :page_facing_up: Roadmap updated
