### PR TITLE
fix(core): History query must also be for self, not just children

### DIFF
--- a/app/access/serializers/teams.py
+++ b/app/access/serializers/teams.py
@@ -75,7 +75,7 @@ class TeamModelSerializer(
 
     team_name = centurion_field.CharField( autolink = True )
 
-    permissions = serializers.PrimaryKeyRelatedField(many = True, queryset=permission_queryset())
+    permissions = serializers.PrimaryKeyRelatedField(many = True, queryset=permission_queryset(), required = False)
 
     class Meta:
 

--- a/app/access/serializers/teams.py
+++ b/app/access/serializers/teams.py
@@ -6,9 +6,10 @@ from access.models import Team
 
 from api.serializers import common
 
+from access.functions.permissions import permission_queryset
 from access.serializers.organization import OrganizationBaseSerializer
 
-from app.serializers.permission import PermissionBaseSerializer
+from app.serializers.permission import Permission, PermissionBaseSerializer
 
 from core import fields as centurion_field
 
@@ -74,6 +75,7 @@ class TeamModelSerializer(
 
     team_name = centurion_field.CharField( autolink = True )
 
+    permissions = serializers.PrimaryKeyRelatedField(many = True, queryset=permission_queryset())
 
     class Meta:
 

--- a/app/access/tests/functional/organization/test_organization_viewset.py
+++ b/app/access/tests/functional/organization/test_organization_viewset.py
@@ -280,6 +280,8 @@ class OrganizationViewSet(
 
     pass
 
+
+
 class OrganizationMetadata(
     ViewSetBase,
     MetadataAttributesFunctional,

--- a/app/access/tests/functional/organization/test_organization_viewset.py
+++ b/app/access/tests/functional/organization/test_organization_viewset.py
@@ -13,6 +13,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
 
 
 
@@ -278,3 +279,14 @@ class OrganizationViewSet(
 ):
 
     pass
+
+class OrganizationMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    MetaDataNavigationEntriesFunctional,
+    TestCase
+):
+
+    menu_id = 'access'
+
+    menu_entry_id = 'organization'

--- a/app/api/react_ui_metadata.py
+++ b/app/api/react_ui_metadata.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.utils.encoding import force_str
 
+from django.contrib.auth.models import ContentType, Permission
+
 from rest_framework import serializers
 from rest_framework_json_api.metadata import JSONAPIMetadata
 from rest_framework.request import clone_request
@@ -166,136 +168,7 @@ class ReactUIMetadata(OverRideJSONAPIMetadata):
         }
 
 
-        metadata['navigation'] = [
-            {
-                "display_name": "Access",
-                "name": "access",
-                "pages": [
-                    {
-                        "display_name": "Organization",
-                        "name": "organization",
-                        "link": "/access/organization"
-                    }
-                ]
-            },
-            {
-                "display_name": "Assistance",
-                "name": "assistance",
-                "pages": [
-                    {
-                        "display_name": "Requests",
-                        "name": "request",
-                        "icon": "ticket_request",
-                        "link": "/assistance/ticket/request"
-                    },
-                    {
-                        "display_name": "Knowledge Base",
-                        "name": "knowledge_base",
-                        "icon": "information",
-                        "link": "/assistance/knowledge_base"
-                    }
-                ]
-            },
-            {
-                "display_name": "ITAM",
-                "name": "itam",
-                "pages": [
-                    {
-                        "display_name": "Devices",
-                        "name": "device",
-                        "icon": "device",
-                        "link": "/itam/device"
-                    },
-                    {
-                        "display_name": "Operating System",
-                        "name": "operating_system",
-                        "link": "/itam/operating_system"
-                    },
-                    {
-                        "display_name": "Software",
-                        "name": "software",
-                        "link": "/itam/software"
-                    }
-                ]
-            },
-            {
-                "display_name": "ITIM",
-                "name": "itim",
-                "pages": [
-                    {
-                        "display_name": "Changes",
-                        "name": "ticket_change",
-                        "link": "/itim/ticket/change"
-                    },
-                    {
-                        "display_name": "Clusters",
-                        "name": "cluster",
-                        "link": "/itim/cluster"
-                    },
-                    {
-                        "display_name": "Incidents",
-                        "name": "ticket_incident",
-                        "link": "/itim/ticket/incident"
-                    },
-                    {
-                        "display_name": "Problems",
-                        "name": "ticket_problem",
-                        "link": "/itim/ticket/problem"
-                    },
-                    {
-                        "display_name": "Services",
-                        "name": "service",
-                        "link": "/itim/service"
-                    },
-                ]
-            },
-            {
-                "display_name": "Config Management",
-                "name": "config_management",
-                "icon": "ansible",
-                "pages": [
-                    {
-                        "display_name": "Groups",
-                        "name": "group",
-                        "icon": 'config_management',
-                        "link": "/config_management/group"
-                    }
-                ]
-            },
-            {
-                "display_name": "Project Management",
-                "name": "project_management",
-                "icon": 'project',
-                "pages": [
-                    {
-                        "display_name": "Projects",
-                        "name": "project",
-                        "icon": 'kanban',
-                        "link": "/project_management/project"
-                    }
-                ]
-            },
-
-            {
-                "display_name": "Settings",
-                "name": "settings",
-                "pages": [
-                    {
-                        "display_name": "System",
-                        "name": "setting",
-                        "icon": "system",
-                        "link": "/settings"
-                    },
-                    {
-                        "display_name": "Task Log",
-                        "name": "celery_log",
-                        # "icon": "settings",
-                        "link": "/settings/celery_log"
-                    }
-                ]
-            }
-        ]
-
+        metadata['navigation'] = self.get_navigation(request.user)
 
         return metadata
 
@@ -377,7 +250,6 @@ class ReactUIMetadata(OverRideJSONAPIMetadata):
             field_info["children"] = self.get_serializer_info(field)
 
         if (
-            # not field_info.get("read_only")
             hasattr(field, "choices")
         ):
             field_info["choices"] = [
@@ -397,3 +269,205 @@ class ReactUIMetadata(OverRideJSONAPIMetadata):
             )
 
         return field_info
+
+
+    _nav = {
+        'access': {
+            "display_name": "Access",
+            "name": "access",
+            "pages": {
+                'view_organization': {
+                    "display_name": "Organization",
+                    "name": "organization",
+                    "link": "/access/organization"
+                }
+            }
+        },
+        'assistance': {
+            "display_name": "Assistance",
+            "name": "assistance",
+            "pages": {
+                'core.view_ticket_request': {
+                    "display_name": "Requests",
+                    "name": "request",
+                    "icon": "ticket_request",
+                    "link": "/assistance/ticket/request"
+                },
+                'view_knowledgebase': {
+                    "display_name": "Knowledge Base",
+                    "name": "knowledge_base",
+                    "icon": "information",
+                    "link": "/assistance/knowledge_base"
+                }
+            }
+        },
+        'itam': {
+            "display_name": "ITAM",
+            "name": "itam",
+            "pages": {
+                'view_device': {
+                    "display_name": "Devices",
+                    "name": "device",
+                    "icon": "device",
+                    "link": "/itam/device"
+                },
+                'view_operatingsystem': {
+                    "display_name": "Operating System",
+                    "name": "operating_system",
+                    "link": "/itam/operating_system"
+                },
+                'view_software': {
+                    "display_name": "Software",
+                    "name": "software",
+                    "link": "/itam/software"
+                }
+            }
+        },
+        'itim': {
+            "display_name": "ITIM",
+            "name": "itim",
+            "pages": {
+                'core.view_ticket_change': {
+                    "display_name": "Changes",
+                    "name": "ticket_change",
+                    "link": "/itim/ticket/change"
+                },
+                'view_cluster': {
+                    "display_name": "Clusters",
+                    "name": "cluster",
+                    "link": "/itim/cluster"
+                },
+                'core.view_ticket_incident': {
+                    "display_name": "Incidents",
+                    "name": "ticket_incident",
+                    "link": "/itim/ticket/incident"
+                },
+                'core.view_ticket_problem': {
+                    "display_name": "Problems",
+                    "name": "ticket_problem",
+                    "link": "/itim/ticket/problem"
+                },
+                'core.view_service': {
+                    "display_name": "Services",
+                    "name": "service",
+                    "link": "/itim/service"
+                },
+            }
+        },
+        'config_management': {
+            "display_name": "Config Management",
+            "name": "config_management",
+            "icon": "ansible",
+            "pages": {
+                'view_configgroups': {
+                    "display_name": "Groups",
+                    "name": "group",
+                    "icon": 'config_management',
+                    "link": "/config_management/group"
+                }
+            }
+        },
+        'project_management': {
+            "display_name": "Project Management",
+            "name": "project_management",
+            "icon": 'project',
+            "pages": {
+                'view_project': {
+                    "display_name": "Projects",
+                    "name": "project",
+                    "icon": 'kanban',
+                    "link": "/project_management/project"
+                }
+            }
+        },
+
+        'settings': {
+            "display_name": "Settings",
+            "name": "settings",
+            "pages": {
+                'view_settings': {
+                    "display_name": "System",
+                    "name": "setting",
+                    "icon": "system",
+                    "link": "/settings"
+                },
+                'django_celery_results.view_taskresult': {
+                    "display_name": "Task Log",
+                    "name": "celery_log",
+                    # "icon": "settings",
+                    "link": "/settings/celery_log"
+                }
+            }
+        }
+    }
+
+
+    def get_navigation(self, user) -> list(dict()):
+        """Render the navigation menu
+
+        Check the users permissions agains `_nav`. if they have the permission, add the
+        menu entry to the navigation to be rendered,
+
+        **No** Menu is to be rendered that contains no menu entries.
+
+        Args:
+            user (User): User object from the request.
+
+        Returns:
+            list(dict()): Rendered navigation menu in the format the UI requires it to be.
+        """
+
+        nav: list = []
+
+        processed_permissions: dict = {}
+
+        for group in user.groups.all():
+
+            for permission in group.permissions.all():
+
+                if str(permission.codename).startswith('view_'):
+
+
+                    if not processed_permissions.get(permission.content_type.app_label, None):
+
+                        processed_permissions.update({permission.content_type.app_label: {}})
+
+                    if permission.codename not in processed_permissions[permission.content_type.app_label]:
+
+                        processed_permissions[permission.content_type.app_label].update({str(permission.codename): '_'})
+
+
+        for app, entry in self._nav.items():
+
+            new_menu_entry: dict = {}
+
+            new_pages: list = []
+
+            if processed_permissions.get(app, None):
+
+                for permission, page in entry['pages'].items():
+
+                    if '.' in permission:
+
+                        app_permission = str(permission).split('.')
+
+                        if processed_permissions[app_permission[0]].get(app_permission[1], None):
+
+                            new_pages += [ page ]
+
+                    else:
+
+                        if processed_permissions[app].get(permission, None):
+
+                            new_pages += [ page ]
+
+
+                if len(new_pages) > 0:
+
+                    new_menu_entry = entry.copy()
+
+                    new_menu_entry.update({ 'pages': new_pages })
+
+                    nav += [ new_menu_entry ]
+
+        return nav

--- a/app/api/react_ui_metadata.py
+++ b/app/api/react_ui_metadata.py
@@ -347,7 +347,7 @@ class ReactUIMetadata(OverRideJSONAPIMetadata):
                     "name": "ticket_problem",
                     "link": "/itim/ticket/problem"
                 },
-                'core.view_service': {
+                'view_service': {
                     "display_name": "Services",
                     "name": "service",
                     "link": "/itim/service"
@@ -443,31 +443,35 @@ class ReactUIMetadata(OverRideJSONAPIMetadata):
 
             new_pages: list = []
 
-            if processed_permissions.get(app, None):
+            # if processed_permissions.get(app, None):    # doesn't cater for `.` in perm
 
-                for permission, page in entry['pages'].items():
+            for permission, page in entry['pages'].items():
 
-                    if '.' in permission:
+                if '.' in permission:
 
-                        app_permission = str(permission).split('.')
+                    app_permission = str(permission).split('.')
+
+                    if processed_permissions.get(app_permission[0], None):
 
                         if processed_permissions[app_permission[0]].get(app_permission[1], None):
 
                             new_pages += [ page ]
 
-                    else:
+                else:
+
+                    if processed_permissions.get(app, None):
 
                         if processed_permissions[app].get(permission, None):
 
                             new_pages += [ page ]
 
 
-                if len(new_pages) > 0:
+            if len(new_pages) > 0:
 
-                    new_menu_entry = entry.copy()
+                new_menu_entry = entry.copy()
 
-                    new_menu_entry.update({ 'pages': new_pages })
+                new_menu_entry.update({ 'pages': new_pages })
 
-                    nav += [ new_menu_entry ]
+                nav += [ new_menu_entry ]
 
         return nav

--- a/app/api/tests/abstract/test_metadata_functional.py
+++ b/app/api/tests/abstract/test_metadata_functional.py
@@ -18,6 +18,8 @@ class MetadataAttributesFunctional:
 
     url_name: str = None
 
+    viewset_type: str = 'list'
+
 
     def test_method_options_request_list_ok(self):
         """Test HTTP/Options Method
@@ -30,11 +32,11 @@ class MetadataAttributesFunctional:
 
         if getattr(self, 'url_kwargs', None):
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type, kwargs = self.url_kwargs)
 
         else:
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type)
 
         response = client.options( url, content_type='application/json' )
 
@@ -52,11 +54,11 @@ class MetadataAttributesFunctional:
 
         if getattr(self, 'url_kwargs', None):
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type, kwargs = self.url_kwargs)
 
         else:
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type)
 
         response = client.options( url, content_type='application/json' )
 
@@ -74,11 +76,11 @@ class MetadataAttributesFunctional:
 
         if getattr(self, 'url_kwargs', None):
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type, kwargs = self.url_kwargs)
 
         else:
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type)
 
         response = client.options( url, content_type='application/json' )
 
@@ -96,11 +98,11 @@ class MetadataAttributesFunctional:
 
         if getattr(self, 'url_kwargs', None):
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type, kwargs = self.url_kwargs)
 
         else:
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type)
 
         response = client.options( url, content_type='application/json' )
 
@@ -118,11 +120,11 @@ class MetadataAttributesFunctional:
 
         if getattr(self, 'url_kwargs', None):
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type, kwargs = self.url_kwargs)
 
         else:
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type)
 
         response = client.options( url, content_type='application/json' )
 
@@ -140,11 +142,11 @@ class MetadataAttributesFunctional:
 
         if getattr(self, 'url_kwargs', None):
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type, kwargs = self.url_kwargs)
 
         else:
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type)
 
         response = client.options( url, content_type='application/json' )
 
@@ -171,11 +173,11 @@ class MetadataAttributesFunctional:
 
         if getattr(self, 'url_kwargs', None):
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type, kwargs = self.url_kwargs)
 
         else:
 
-            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+            url = reverse(self.app_namespace + ':' + self.url_name + '-' + self.viewset_type)
 
         response = client.options( url, content_type='application/json' )
 

--- a/app/api/tests/abstract/test_metadata_functional.py
+++ b/app/api/tests/abstract/test_metadata_functional.py
@@ -28,7 +28,7 @@ class MetadataAttributesFunctional:
         client = Client()
         client.force_login(self.view_user)
 
-        if self.url_kwargs:
+        if getattr(self, 'url_kwargs', None):
 
             url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
 
@@ -50,7 +50,7 @@ class MetadataAttributesFunctional:
         client = Client()
         client.force_login(self.view_user)
 
-        if self.url_kwargs:
+        if getattr(self, 'url_kwargs', None):
 
             url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
 
@@ -72,7 +72,7 @@ class MetadataAttributesFunctional:
         client = Client()
         client.force_login(self.view_user)
 
-        if self.url_kwargs:
+        if getattr(self, 'url_kwargs', None):
 
             url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
 
@@ -94,7 +94,7 @@ class MetadataAttributesFunctional:
         client = Client()
         client.force_login(self.view_user)
 
-        if self.url_kwargs:
+        if getattr(self, 'url_kwargs', None):
 
             url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
 
@@ -116,7 +116,7 @@ class MetadataAttributesFunctional:
         client = Client()
         client.force_login(self.view_user)
 
-        if self.url_kwargs:
+        if getattr(self, 'url_kwargs', None):
 
             url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
 
@@ -138,7 +138,7 @@ class MetadataAttributesFunctional:
         client = Client()
         client.force_login(self.view_user)
 
-        if self.url_kwargs:
+        if getattr(self, 'url_kwargs', None):
 
             url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
 
@@ -169,7 +169,7 @@ class MetadataAttributesFunctional:
         client = Client()
         client.force_login(self.view_user)
 
-        if self.url_kwargs:
+        if getattr(self, 'url_kwargs', None):
 
             url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
 

--- a/app/api/tests/abstract/test_metadata_functional.py
+++ b/app/api/tests/abstract/test_metadata_functional.py
@@ -489,7 +489,6 @@ class MetadataAttributesFunctional:
         assert type(response.data['urls']['self']) is str
 
 
-
     @pytest.mark.skip(reason='to be written')
     def test_method_options_no_field_is_generic(self):
         """Test HTTP/Options Method
@@ -500,3 +499,359 @@ class MetadataAttributesFunctional:
         """
 
         pass
+
+
+
+class MetaDataNavigationEntriesFunctional:
+    """ Test cases for the Navigation menu
+
+    Navigation menu is rendered as part of the API when a HTTP/OPTIONS
+    request has been made. Each menu entry requires that a user has View
+    permissions for that entry to be visible.
+
+    **No** menu entry is to be returned for **any** user whom does not 
+    have the corresponding view permission.
+
+    These test cases are for any model that has a navigation menu entry.
+
+    ## Tests
+
+    - Ensure add user does not have menu entry
+    - Ensure change user does not have menu entry
+    - Ensure delete user does not have menu entry
+    - Ensure the view user has menu entry
+    - No menu to return without pages for add user
+    - No menu to return without pages for change user
+    - No menu to return without pages for delete user
+    - No menu to return without pages for view user
+    """
+
+    menu_id: str = None
+    """ Name of the Menu entry
+
+    Match for .navigation[i][name]
+    """
+
+    menu_entry_id: str = None
+    """Name of the menu entry
+
+    Match for .navigation[i][pages][i][name]
+    """
+
+    app_namespace:str = None
+    """application namespace"""
+
+    url_name: str = None
+    """url name"""
+
+    url_kwargs: dict = None
+    """View URL kwargs"""
+
+    add_user = None
+    """ User with add permission"""
+
+    change_user = None
+    """ User with change permission"""
+
+    delete_user = None
+    """ User with delete permission"""
+
+    view_user = None
+    """ User with view permission"""
+
+
+
+    def test_navigation_entry_add_user(self):
+        """Test HTTP/Options Method Navigation Entry
+
+        Ensure that a user with add permission, does not
+        have the menu entry within navigation
+        """
+
+        client = Client()
+        client.force_login(self.add_user)
+
+
+        if getattr(self, 'url_kwargs', None):
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+
+        else:
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+
+        response = client.options(
+            url,
+            content_type='application/json'
+        )
+
+        no_menu_entry_found: bool = True
+
+        for nav_menu in response.data['navigation']:
+
+            if nav_menu['name'] == self.menu_id:
+
+                for menu_entry in nav_menu['pages']:
+
+                    if menu_entry['name'] == self.menu_entry_id:
+
+                        no_menu_entry_found = False
+
+        assert no_menu_entry_found
+
+
+
+    def test_navigation_no_empty_menu_add_user(self):
+        """Test HTTP/Options Method Navigation Entry
+
+        Ensure that a user with add permission, does not
+        have any nave menu without pages
+        """
+
+        client = Client()
+        client.force_login(self.add_user)
+
+        if getattr(self, 'url_kwargs', None):
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+
+        else:
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+
+        response = client.options(
+            url,
+            content_type='application/json'
+        )
+
+        no_empty_menu_found: bool = True
+
+        for nav_menu in response.data['navigation']:
+
+            if len(nav_menu['pages']) == 0:
+
+                no_empty_menu_found = False
+
+        assert no_empty_menu_found
+
+
+
+    def test_navigation_entry_change_user(self):
+        """Test HTTP/Options Method Navigation Entry
+
+        Ensure that a user with change permission, does not
+        have the menu entry within navigation
+        """
+
+        client = Client()
+        client.force_login(self.change_user)
+
+        if getattr(self, 'url_kwargs', None):
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+
+        else:
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+
+        response = client.options(
+            url,
+            content_type='application/json'
+        )
+
+        no_menu_entry_found: bool = True
+
+        for nav_menu in response.data['navigation']:
+
+            if nav_menu['name'] == self.menu_id:
+
+                for menu_entry in nav_menu['pages']:
+
+                    if menu_entry['name'] == self.menu_entry_id:
+
+                        no_menu_entry_found = False
+
+        assert no_menu_entry_found
+
+
+
+    def test_navigation_no_empty_menu_change_user(self):
+        """Test HTTP/Options Method Navigation Entry
+
+        Ensure that a user with change permission, does not
+        have any nave menu without pages
+        """
+
+        client = Client()
+        client.force_login(self.change_user)
+
+        if getattr(self, 'url_kwargs', None):
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+
+        else:
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+
+        response = client.options(
+            url,
+            content_type='application/json'
+        )
+
+        no_empty_menu_found: bool = True
+
+        for nav_menu in response.data['navigation']:
+
+            if len(nav_menu['pages']) == 0:
+
+                no_empty_menu_found = False
+
+        assert no_empty_menu_found
+
+
+
+    def test_navigation_entry_delete_user(self):
+        """Test HTTP/Options Method Navigation Entry
+
+        Ensure that a user with delete permission, does not
+        have the menu entry within navigation
+        """
+
+        client = Client()
+        client.force_login(self.delete_user)
+
+        if getattr(self, 'url_kwargs', None):
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+
+        else:
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+
+        response = client.options(
+            url,
+            content_type='application/json'
+        )
+
+        no_menu_entry_found: bool = True
+
+        for nav_menu in response.data['navigation']:
+
+            if nav_menu['name'] == self.menu_id:
+
+                for menu_entry in nav_menu['pages']:
+
+                    if menu_entry['name'] == self.menu_entry_id:
+
+                        no_menu_entry_found = False
+
+        assert no_menu_entry_found
+
+
+
+    def test_navigation_no_empty_menu_delete_user(self):
+        """Test HTTP/Options Method Navigation Entry
+
+        Ensure that a user with delete permission, does not
+        have any nave menu without pages
+        """
+
+        client = Client()
+        client.force_login(self.delete_user)
+
+        if getattr(self, 'url_kwargs', None):
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+
+        else:
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+
+        response = client.options(
+            url,
+            content_type='application/json'
+        )
+
+        no_empty_menu_found: bool = True
+
+        for nav_menu in response.data['navigation']:
+
+            if len(nav_menu['pages']) == 0:
+
+                no_empty_menu_found = False
+
+        assert no_empty_menu_found
+
+
+
+    def test_navigation_entry_view_user(self):
+        """Test HTTP/Options Method Navigation Entry
+
+        Ensure that a user with view permission,
+        has the menu entry within navigation
+        """
+
+        client = Client()
+        client.force_login(self.view_user)
+
+        if getattr(self, 'url_kwargs', None):
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+
+        else:
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+
+        response = client.options(
+            url,
+            content_type='application/json'
+        )
+
+        menu_entry_found: bool = False
+
+        for nav_menu in response.data['navigation']:
+
+            if nav_menu['name'] == self.menu_id:
+
+                for menu_entry in nav_menu['pages']:
+
+                    if menu_entry['name'] == self.menu_entry_id:
+
+                        menu_entry_found = True
+
+        assert menu_entry_found
+
+
+
+    def test_navigation_no_empty_menu_view_user(self):
+        """Test HTTP/Options Method Navigation Entry
+
+        Ensure that a user with view permission, does not
+        have any nave menu without pages
+        """
+
+        client = Client()
+        client.force_login(self.view_user)
+
+        if getattr(self, 'url_kwargs', None):
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list', kwargs = self.url_kwargs)
+
+        else:
+
+            url = reverse(self.app_namespace + ':' + self.url_name + '-list')
+
+        response = client.options(
+            url,
+            content_type='application/json'
+        )
+
+        no_empty_menu_found: bool = True
+
+        for nav_menu in response.data['navigation']:
+
+            if len(nav_menu['pages']) == 0:
+
+                no_empty_menu_found = False
+
+        assert no_empty_menu_found

--- a/app/assistance/tests/functional/knowledge_base/test_knowledge_base_viewset.py
+++ b/app/assistance/tests/functional/knowledge_base/test_knowledge_base_viewset.py
@@ -12,6 +12,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
 
 from assistance.models.knowledge_base import KnowledgeBase
 
@@ -212,3 +213,16 @@ class KnowledgeBaseViewSet(
 ):
 
     pass
+
+
+
+class KnowledgeBaseMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    MetaDataNavigationEntriesFunctional,
+    TestCase
+):
+
+    menu_id = 'assistance'
+
+    menu_entry_id = 'knowledge_base'

--- a/app/assistance/tests/functional/knowledge_base_category/test_knowledge_base_category_viewset.py
+++ b/app/assistance/tests/functional/knowledge_base_category/test_knowledge_base_category_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from assistance.models.knowledge_base import KnowledgeBaseCategory
 
@@ -203,6 +204,16 @@ class KnowledgeBaseCategoryViewSet(
     ViewSetBase,
     SerializersTestCases,
     TestCase,
+):
+
+    pass
+
+
+
+class KnowledgeBaseCategoryMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
 ):
 
     pass

--- a/app/assistance/tests/functional/ticket_request/test_ticket_request_viewset.py
+++ b/app/assistance/tests/functional/ticket_request/test_ticket_request_viewset.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
+
 from core.tests.abstract.test_ticket_viewset import Ticket, TicketViewSetBase, TicketViewSetPermissionsAPI, TicketViewSet
 
 
@@ -29,3 +31,16 @@ class TicketRequestViewSet(
 ):
 
     pass
+
+
+
+class TicketRequestMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    MetaDataNavigationEntriesFunctional,
+    TestCase
+):
+
+    menu_id = 'assistance'
+
+    menu_entry_id = 'request'

--- a/app/config_management/tests/functional/config_groups/test_config_groups_viewset.py
+++ b/app/config_management/tests/functional/config_groups/test_config_groups_viewset.py
@@ -12,6 +12,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
 
 from config_management.models.groups import ConfigGroups
 
@@ -207,3 +208,16 @@ class ConfigGroupsViewSet(
 ):
 
     pass
+
+
+
+class ConfigGroupsMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    MetaDataNavigationEntriesFunctional,
+    TestCase
+):
+
+    menu_id = 'config_management'
+
+    menu_entry_id = 'group'

--- a/app/config_management/tests/functional/config_groups_software/test_config_groups_software_viewset.py
+++ b/app/config_management/tests/functional/config_groups_software/test_config_groups_software_viewset.py
@@ -12,6 +12,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from config_management.models.groups import ConfigGroups, ConfigGroupSoftware, Software, SoftwareVersion
 
@@ -243,6 +244,16 @@ class ConfigGroupSoftwarePermissionsAPI(
 class ConfigGroupSoftwareViewSet(
     ViewSetBase,
     SerializersTestCases,
+    TestCase
+):
+
+    pass
+
+
+
+class ConfigGroupSoftwareMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
     TestCase
 ):
 

--- a/app/core/tests/functional/manufacturer/test_manufacturer_viewset.py
+++ b/app/core/tests/functional/manufacturer/test_manufacturer_viewset.py
@@ -12,6 +12,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from core.models.manufacturer import Manufacturer
 
@@ -203,6 +204,16 @@ class ManufacturerPermissionsAPI(
 class ManufacturerViewSet(
     ViewSetBase,
     SerializersTestCases,
+    TestCase
+):
+
+    pass
+
+
+
+class ManufacturerMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
     TestCase
 ):
 

--- a/app/core/tests/functional/related_ticket/test_related_ticket_viewset.py
+++ b/app/core/tests/functional/related_ticket/test_related_ticket_viewset.py
@@ -15,16 +15,13 @@ from api.tests.abstract.api_permissions_viewset import (
     APIPermissionDelete,
     APIPermissionView,
 )
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from core.models.ticket.ticket import Ticket, RelatedTickets
 
 
 
-class RelatedTicketsPermissionsAPI(
-    APIPermissionDelete,
-    APIPermissionView,
-    TestCase,
-):
+class ViewSetBase:
 
     model = RelatedTickets
 
@@ -209,6 +206,13 @@ class RelatedTicketsPermissionsAPI(
 
 
 
+class RelatedTicketsPermissionsAPI(
+    ViewSetBase,
+    APIPermissionDelete,
+    APIPermissionView,
+    TestCase,
+):
+
     def test_add_has_permission_post_not_allowed(self):
         """ Check correct permission for add 
 
@@ -273,3 +277,13 @@ class RelatedTicketsPermissionsAPI(
         """
 
         pass
+
+
+
+class RelatedTicketsMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
+
+    pass

--- a/app/core/tests/functional/test_history/test_history_viewset.py
+++ b/app/core/tests/functional/test_history/test_history_viewset.py
@@ -12,6 +12,7 @@ from django.test import Client, TestCase
 from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissionView
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from core.models.history import History
 
@@ -19,7 +20,7 @@ from itam.models.device import Device
 
 
 
-class HistoryPermissionsAPI(APIPermissionView, TestCase):
+class ViewSetBase:
 
     model = History
 
@@ -218,6 +219,15 @@ class HistoryPermissionsAPI(APIPermissionView, TestCase):
             user = self.different_organization_user
         )
 
+
+
+class HistoryPermissionsAPI(
+    ViewSetBase,
+    APIPermissionView,
+    TestCase
+):
+
+
     def test_view_list_has_permission(self):
         """ Check correct permission for view
 
@@ -326,3 +336,12 @@ class HistoryPermissionsAPI(APIPermissionView, TestCase):
 
         pass
 
+
+
+class HistoryMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
+
+    pass

--- a/app/core/tests/functional/ticket_category/test_ticket_category_viewset.py
+++ b/app/core/tests/functional/ticket_category/test_ticket_category_viewset.py
@@ -12,6 +12,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from core.models.ticket.ticket_category import TicketCategory
 
@@ -200,6 +201,16 @@ class TicketCategoryViewSet(
     ViewSetBase,
     SerializersTestCases,
     TestCase,
+):
+
+    pass
+
+
+
+class TicketCategoryMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
 ):
 
     pass

--- a/app/core/tests/functional/ticket_comment/test_ticket_comment_viewset.py
+++ b/app/core/tests/functional/ticket_comment/test_ticket_comment_viewset.py
@@ -6,6 +6,7 @@ from django.test import Client, TestCase
 from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from core.models.ticket.ticket_comment import Ticket, TicketComment
 
@@ -13,10 +14,7 @@ from settings.models.user_settings import UserSettings
 
 
 
-class TicketCommentPermissionsAPI(
-    APIPermissions,
-    TestCase
-):
+class ViewSetBase:
     """ Test Cases common to ALL ticket types """
 
     model = TicketComment
@@ -230,6 +228,11 @@ class TicketCommentPermissionsAPI(
         )
 
 
+class TicketCommentPermissionsAPI(
+    ViewSetBase,
+    APIPermissions,
+    TestCase
+):
     def test_returned_results_only_user_orgs(self):
         """Test not required
 
@@ -238,3 +241,13 @@ class TicketCommentPermissionsAPI(
         """
 
         pass
+
+
+
+class TicketCommentMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
+
+    pass

--- a/app/core/tests/functional/ticket_comment_category/test_ticket_comment_category_viewset.py
+++ b/app/core/tests/functional/ticket_comment_category/test_ticket_comment_category_viewset.py
@@ -12,6 +12,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from core.models.ticket.ticket_comment_category import TicketCommentCategory
 
@@ -199,6 +200,16 @@ class TicketCommentCategoryPermissionsAPI(
 class TicketCommentCategoryViewSet(
     ViewSetBase,
     SerializersTestCases,
+    TestCase
+):
+
+    pass
+
+
+
+class TicketCommentCategoryMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
     TestCase
 ):
 

--- a/app/core/viewsets/history.py
+++ b/app/core/viewsets/history.py
@@ -1,3 +1,5 @@
+from django.db.models import Q
+
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiResponse
 
 from api.viewsets.common import ModelViewSet
@@ -46,9 +48,10 @@ class ViewSet(ModelViewSet):
         queryset = super().get_queryset()
 
         self.queryset = queryset.filter(
-            item_parent_class = self.kwargs['model_class'],
-            item_parent_pk = self.kwargs['model_id']
-        ).order_by('-created')
+            Q(item_pk = self.kwargs['model_id'], item_class = self.kwargs['model_class'])
+            |
+            Q(item_parent_pk = self.kwargs['model_id'], item_parent_class = self.kwargs['model_class'])
+        )
 
         return self.queryset
 

--- a/app/core/viewsets/ticket.py
+++ b/app/core/viewsets/ticket.py
@@ -251,17 +251,6 @@ class TicketViewSet(ModelViewSet):
 
 
             if (
-                self.action == 'list'
-            ):
-
-                user_settings = UserSettings.objects.get(
-                    user = self.request.user
-                )
-
-                organization = user_settings.default_organization.id
-
-
-            elif (
                 self.action == 'create'
             ):
 

--- a/app/itam/tests/functional/device/test_device_viewset.py
+++ b/app/itam/tests/functional/device/test_device_viewset.py
@@ -6,9 +6,10 @@ from django.shortcuts import reverse
 from django.test import Client, TestCase
 
 from access.models import Organization, Team, TeamUsers, Permission
-from api.tests.abstract.api_serializer_viewset import SerializersTestCases
 
+from api.tests.abstract.api_serializer_viewset import SerializersTestCases
 from api.tests.abstract.api_permissions_viewset import APIPermissions
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
 
 from itam.models.device import Device
 
@@ -199,3 +200,16 @@ class DeviceViewSet(
 ):
 
     pass
+
+
+
+class DeviceMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    MetaDataNavigationEntriesFunctional,
+    TestCase
+):
+
+    menu_id = 'itam'
+
+    menu_entry_id = 'device'

--- a/app/itam/tests/functional/device_model/test_device_model_viewset.py
+++ b/app/itam/tests/functional/device_model/test_device_model_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from itam.models.device import DeviceModel
 
@@ -195,6 +196,16 @@ class DeviceModelPermissionsAPI(
 class DeviceModelViewSet(
     ViewSetBase,
     SerializersTestCases,
+    TestCase
+):
+
+    pass
+
+
+
+class DeviceModelMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
     TestCase
 ):
 

--- a/app/itam/tests/functional/device_operating_system/test_device_operating_system_viewset.py
+++ b/app/itam/tests/functional/device_operating_system/test_device_operating_system_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from itam.serializers.device_operating_system import Device, DeviceOperatingSystem, DeviceOperatingSystemModelSerializer
 from itam.models.operating_system import OperatingSystem, OperatingSystemVersion
@@ -253,6 +254,16 @@ class DeviceOperatingSystemPermissionsAPI(
 class DeviceOperatingViewSet(
     ViewSetBase,
     SerializersTestCases,
+    TestCase
+):
+
+    pass
+
+
+
+class DeviceOperatingMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
     TestCase
 ):
 

--- a/app/itam/tests/functional/device_type/test_device_type_viewset.py
+++ b/app/itam/tests/functional/device_type/test_device_type_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from itam.models.device import DeviceType
 
@@ -196,6 +197,16 @@ class DeviceTypeViewSet(
     ViewSetBase,
     SerializersTestCases,
     TestCase,
+):
+
+    pass
+
+
+
+class DeviceTypeMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
 ):
 
     pass

--- a/app/itam/tests/functional/endpoint_operating_system_installs/test_operating_system_installs_viewset.py
+++ b/app/itam/tests/functional/endpoint_operating_system_installs/test_operating_system_installs_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissionView
 from api.tests.abstract.api_serializer_viewset import SerializerView
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from itam.serializers.device_operating_system import Device, DeviceOperatingSystem, DeviceOperatingSystemModelSerializer
 from itam.models.operating_system import OperatingSystem, OperatingSystemVersion
@@ -176,6 +177,16 @@ class OperatingSystemInstallsPermissionsAPI(
 class OperatingSystemInstallsViewSet(
     ViewSetBase,
     SerializerView,
+    TestCase
+):
+
+    pass
+
+
+
+class OperatingSystemInstallsMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
     TestCase
 ):
 

--- a/app/itam/tests/functional/endpoint_software_installs/test_software_installs_viewset.py
+++ b/app/itam/tests/functional/endpoint_software_installs/test_software_installs_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from itam.models.device import Device, DeviceSoftware
 from itam.models.software import Software
@@ -225,6 +226,16 @@ class SoftwareInstallsPermissionsAPI(
 class SoftwareInstallsViewSet(
     ViewSetBase,
     SerializersTestCases,
+    TestCase
+):
+
+    pass
+
+
+
+class SoftwareInstallsMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
     TestCase
 ):
 

--- a/app/itam/tests/functional/operating_system/test_operating_system_viewset.py
+++ b/app/itam/tests/functional/operating_system/test_operating_system_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
 
 from itam.models.operating_system import OperatingSystem
 
@@ -199,3 +200,16 @@ class OperatingSystemViewSet(
 ):
 
     pass
+
+
+
+class OperatingSystemMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    MetaDataNavigationEntriesFunctional,
+    TestCase
+):
+
+    menu_id = 'itam'
+
+    menu_entry_id = 'operating_system'

--- a/app/itam/tests/functional/operating_system_version/test_operating_system_version_viewset.py
+++ b/app/itam/tests/functional/operating_system_version/test_operating_system_version_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from itam.models.operating_system import OperatingSystem, OperatingSystemVersion
 
@@ -203,5 +204,15 @@ class OperatingSystemVersionPermissionsAPI(ViewSetBase, APIPermissions, TestCase
 
 
 class OperatingSystemVersionViewSetBase(ViewSetBase, SerializersTestCases, TestCase):
+
+    pass
+
+
+
+class OperatingSystemVersionMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
 
     pass

--- a/app/itam/tests/functional/software/test_software_viewset.py
+++ b/app/itam/tests/functional/software/test_software_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
 
 from itam.models.software import Software
 
@@ -191,3 +192,16 @@ class SoftwarePermissionsAPI(ViewSetBase, APIPermissions, TestCase):
 class SoftwareViewSet(ViewSetBase, SerializersTestCases, TestCase):
 
     pass
+
+
+
+class SoftwareMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    MetaDataNavigationEntriesFunctional,
+    TestCase
+):
+
+    menu_id = 'itam'
+
+    menu_entry_id = 'software'

--- a/app/itam/tests/functional/software_category/test_software_category_viewset.py
+++ b/app/itam/tests/functional/software_category/test_software_category_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from itam.models.software import SoftwareCategory
 
@@ -189,5 +190,15 @@ class SoftwareCategoryPermissionsAPI(ViewSetBase, APIPermissions, TestCase):
 
 
 class SoftwareCategoryViewSet(ViewSetBase, SerializersTestCases, TestCase):
+
+    pass
+
+
+
+class SoftwareCategoryMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
 
     pass

--- a/app/itam/tests/functional/software_version/test_software_version_viewset.py
+++ b/app/itam/tests/functional/software_version/test_software_version_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from itam.models.software import Software, SoftwareVersion
 
@@ -202,5 +203,15 @@ class SoftwareVersionPermissionsAPI(ViewSetBase, APIPermissions, TestCase):
 
 
 class SoftwareVersionViewSet(ViewSetBase, SerializersTestCases, TestCase):
+
+    pass
+
+
+
+class SoftwareVersionMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
 
     pass

--- a/app/itim/tests/functional/cluster/test_cluster_viewset.py
+++ b/app/itim/tests/functional/cluster/test_cluster_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
 
 from itim.models.clusters import Cluster
 
@@ -191,3 +192,16 @@ class ClusterPermissionsAPI(ViewSetBase, APIPermissions, TestCase):
 class ClusterViewSet(ViewSetBase, SerializersTestCases, TestCase):
 
     pass
+
+
+
+class ClusterMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    MetaDataNavigationEntriesFunctional,
+    TestCase
+):
+
+    menu_id = 'itim'
+
+    menu_entry_id = 'cluster'

--- a/app/itim/tests/functional/cluster_types/test_cluster_type_viewset.py
+++ b/app/itim/tests/functional/cluster_types/test_cluster_type_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from itim.models.clusters import ClusterType
 
@@ -190,5 +191,15 @@ class ClusterTypePermissionsAPI(ViewSetBase, APIPermissions, TestCase):
 
 
 class ClusterTypeViewSet(ViewSetBase, SerializersTestCases, TestCase):
+
+    pass
+
+
+
+class ClusterTypeMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
 
     pass

--- a/app/itim/tests/functional/port/test_port_viewset.py
+++ b/app/itim/tests/functional/port/test_port_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from itim.models.services import Port
 
@@ -192,5 +193,15 @@ class PortPermissionsAPI(ViewSetBase, APIPermissions, TestCase):
 
 
 class PortViewSet(ViewSetBase, SerializersTestCases, TestCase):
+
+    pass
+
+
+
+class PortMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
 
     pass

--- a/app/itim/tests/functional/service/test_service_viewset.py
+++ b/app/itim/tests/functional/service/test_service_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
 
 from itam.models.device import Device
 
@@ -213,3 +214,16 @@ class ServicePermissionsAPI(ViewSetBase, APIPermissions, TestCase):
 class ServiceViewSet(ViewSetBase, SerializersTestCases, TestCase):
 
     pass
+
+
+
+class ServiceMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    MetaDataNavigationEntriesFunctional,
+    TestCase
+):
+
+    menu_id = 'itim'
+
+    menu_entry_id = 'service'

--- a/app/itim/tests/functional/ticket_change/test_ticket_change_viewset.py
+++ b/app/itim/tests/functional/ticket_change/test_ticket_change_viewset.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from core.tests.abstract.test_ticket_viewset import Ticket, TicketViewSetBase, TicketViewSetPermissionsAPI, TicketViewSet
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
 
 
 class ViewSetBase( TicketViewSetBase ):
@@ -28,3 +29,16 @@ class TicketChangeViewSet(
 ):
 
     pass
+
+
+
+class TicketChangeMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    MetaDataNavigationEntriesFunctional,
+    TestCase
+):
+
+    menu_id = 'itim'
+
+    menu_entry_id = 'ticket_change'

--- a/app/itim/tests/functional/ticket_incident/test_ticket_incident_viewset.py
+++ b/app/itim/tests/functional/ticket_incident/test_ticket_incident_viewset.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from core.tests.abstract.test_ticket_viewset import Ticket, TicketViewSetBase, TicketViewSetPermissionsAPI, TicketViewSet
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
 
 
 class ViewSetBase( TicketViewSetBase ):
@@ -28,3 +29,16 @@ class TicketIncidentViewSet(
 ):
 
     pass
+
+
+
+class TicketIncidentMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    MetaDataNavigationEntriesFunctional,
+    TestCase
+):
+
+    menu_id = 'itim'
+
+    menu_entry_id = 'ticket_incident'

--- a/app/itim/tests/functional/ticket_problem/test_ticket_problem_viewset.py
+++ b/app/itim/tests/functional/ticket_problem/test_ticket_problem_viewset.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from core.tests.abstract.test_ticket_viewset import Ticket, TicketViewSetBase, TicketViewSetPermissionsAPI, TicketViewSet
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
 
 
 class ViewSetBase( TicketViewSetBase ):
@@ -28,3 +29,16 @@ class TicketProblemViewSet(
 ):
 
     pass
+
+
+
+class TicketProblemMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    MetaDataNavigationEntriesFunctional,
+    TestCase
+):
+
+    menu_id = 'itim'
+
+    menu_entry_id = 'ticket_problem'

--- a/app/project_management/tests/functional/project/test_project_viewset.py
+++ b/app/project_management/tests/functional/project/test_project_viewset.py
@@ -9,6 +9,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional, MetaDataNavigationEntriesFunctional
 
 from project_management.models.projects import Project
 
@@ -274,3 +275,16 @@ class ProjectPermissionsAPI(ViewSetBase, APIPermissions, TestCase):
 class ProjectViewSet(ViewSetBase, SerializersTestCases, TestCase):
 
     pass
+
+
+
+class ProjectMetadata(
+    ViewSetBase,
+    MetaDataNavigationEntriesFunctional,
+    MetadataAttributesFunctional,
+    TestCase
+):
+
+    menu_id = 'project_management'
+
+    menu_entry_id = 'project'

--- a/app/project_management/tests/functional/project_milestone/test_project_milestone_viewset.py
+++ b/app/project_management/tests/functional/project_milestone/test_project_milestone_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from project_management.models.project_milestone import Project, ProjectMilestone
 
@@ -203,5 +204,15 @@ class ProjectMilestonePermissionsAPI(ViewSetBase, APIPermissions, TestCase):
 
 
 class ProjectMilestoneViewSet(ViewSetBase, SerializersTestCases, TestCase):
+
+    pass
+
+
+
+class ProjectMilestoneMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
 
     pass

--- a/app/project_management/tests/functional/project_state/test_project_state_viewset.py
+++ b/app/project_management/tests/functional/project_state/test_project_state_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from project_management.models.project_states import ProjectState
 
@@ -189,5 +190,15 @@ class ProjectStatePermissionsAPI(ViewSetBase, APIPermissions, TestCase):
 
 
 class ProjectStateViewSet(ViewSetBase, SerializersTestCases, TestCase):
+
+    pass
+
+
+
+class ProjectStateMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
 
     pass

--- a/app/project_management/tests/functional/project_task/test_project_task_viewset.py
+++ b/app/project_management/tests/functional/project_task/test_project_task_viewset.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from core.tests.abstract.test_ticket_viewset import Ticket, TicketViewSetBase, TicketViewSetPermissionsAPI, TicketViewSet
-
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 
 class ViewSetBase( TicketViewSetBase ):
@@ -26,6 +26,16 @@ class TicketProjectTaskViewSet(
     TicketViewSet,
     ViewSetBase,
     TestCase,
+):
+
+    pass
+
+
+
+class TicketProjectTaskMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
 ):
 
     pass

--- a/app/project_management/tests/functional/project_type/test_project_type_viewset.py
+++ b/app/project_management/tests/functional/project_type/test_project_type_viewset.py
@@ -8,6 +8,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from project_management.models.project_types import ProjectType
 
@@ -189,5 +190,15 @@ class ProjectTypePermissionsAPI(ViewSetBase, APIPermissions, TestCase):
 
 
 class ProjectTypeViewSet(ViewSetBase, SerializersTestCases, TestCase):
+
+    pass
+
+
+
+class ProjectTypeMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
 
     pass

--- a/app/settings/tests/functional/app_settings/test_app_settings_viewset.py
+++ b/app/settings/tests/functional/app_settings/test_app_settings_viewset.py
@@ -16,6 +16,7 @@ from api.tests.abstract.api_serializer_viewset import (
     SerializerChange,
     SerializerView,
 )
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from settings.models.app_settings import AppSettings
 
@@ -241,3 +242,21 @@ class AppSettingsViewSet(
 ):
 
     pass
+
+
+
+class AppSettingsMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
+
+    viewset_type = 'detail'
+
+    @classmethod
+    def setUpTestData(self):
+
+        super().setUpTestData()
+
+        self.url_kwargs = self.url_view_kwargs
+

--- a/app/settings/tests/functional/external_links/test_external_link_viewset.py
+++ b/app/settings/tests/functional/external_links/test_external_link_viewset.py
@@ -12,6 +12,7 @@ from access.models import Organization, Team, TeamUsers, Permission
 
 from api.tests.abstract.api_permissions_viewset import APIPermissions
 from api.tests.abstract.api_serializer_viewset import SerializersTestCases
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 from settings.models.external_link import ExternalLink
 
@@ -198,5 +199,15 @@ class ExternalLinkPermissionsAPI(ViewSetBase, APIPermissions, TestCase):
 
 
 class ExternalLinkViewSet(ViewSetBase, SerializersTestCases, TestCase):
+
+    pass
+
+
+
+class ExternalLinkMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
 
     pass

--- a/app/settings/tests/functional/user_settings/test_user_settings_viewset.py
+++ b/app/settings/tests/functional/user_settings/test_user_settings_viewset.py
@@ -16,6 +16,7 @@ from api.tests.abstract.api_serializer_viewset import (
     SerializerChange,
     SerializerView,
 )
+from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional
 
 
 from settings.models.user_settings import UserSettings
@@ -267,3 +268,20 @@ class UserSettingsViewSet(
 ):
 
     pass
+
+
+
+class UserSettingsMetadata(
+    ViewSetBase,
+    MetadataAttributesFunctional,
+    TestCase
+):
+
+    viewset_type = 'detail'
+
+    @classmethod
+    def setUpTestData(self):
+
+        super().setUpTestData()
+
+        self.url_kwargs = self.url_view_kwargs

--- a/docs/projects/centurion_erp/development/views.md
+++ b/docs/projects/centurion_erp/development/views.md
@@ -40,6 +40,8 @@ Views are used with Centurion ERP to Fetch the data for rendering.
 
     - _Functional test cases_ `from api.tests.abstract.api_permissions_viewset import APIPermission`
 
+- View Added to Navigation
+
 
 ## Permissions
 
@@ -64,6 +66,72 @@ def get_dynamic_permissions(self):
     return super().get_permission_required()
 
 ```
+
+
+## Navigation
+
+Although Centurion ERP is a Rest API application, there is a UI. The UI uses data from Centurion's API to render the view that the end user sees. One of those items is the navigation structure.
+
+Location of the navigation is in `app/api/react_ui_metadata.py` under the attribute `_nav`.
+
+
+### Menu Entry
+
+When adding a view, that is also meant to be seen by the end user, a navigation entry must be added to the correct navgation menu. The entry is a python dictionary and has the following format.
+
+``` pyhton
+
+{
+    '<app name>.<permission name>': {
+        "display_name": "<menu entry name>",
+        "name": "<html id>",
+        "icon": "<menu entry icon>",
+        "link": "<relative url.>"
+    }
+}
+
+```
+
+- `app name` _Optional_ is the centurion application name the model belongs to. This entry should only be supplied if the application name for the entry does not match the application for the [navigation menu](#menu).
+
+- `permission name` is the centurion permission required for this menu entry to be rendered for the end user.
+
+- `display_name` Menu entry name that the end user will see
+
+- `name` This is used as part of the html rendering of the page. **must be unique** across ALL menu entries
+
+- `icon` _Optional_ if specified, this is the name of the icon that the UI will place next to the menu entry. If this is not specified, the name key is used as the icon name.
+
+- `link` the relative URL for the entry. this will be the relative URL of the API after the API's version number. _i.e. `/api/v2/assistance/ticket/request` would become `/assistance/ticket/request`_
+
+
+### Menu
+
+The navigation menu is obtained by the UI as part of the metadata. The structure of the menu is a python dictionary in the following format:
+
+``` python
+
+ {
+        '<app name>': {
+            "display_name": "<Menu entry>",
+            "name": "<menu id>",
+            "pages": {
+                '<menu entries>'
+            }
+        }
+ }
+
+```
+
+- `app name` the centurion application name the menu belongs to.
+
+- `display_name` Menu name that the end user will see
+
+- `name` This is used as part of the html rendering of the page. **must be unique** across ALL menu entries
+
+- `pages` [Menu entry](#menu-entry) dictionaries.
+
+Upon the UI requesting the navigation menu, the users permission are obtained, and if they have the permission for the menu entry within **any** organization, they will be presented with the menu that has a menu entries.
 
 
 ## Pre v1.3 Docs

--- a/docs/projects/centurion_erp/development/views.md
+++ b/docs/projects/centurion_erp/development/views.md
@@ -40,6 +40,10 @@ Views are used with Centurion ERP to Fetch the data for rendering.
 
     - _Functional test cases_ `from api.tests.abstract.api_permissions_viewset import APIPermission`
 
+    - _Functional test cases_ (Only required if model has an API endpoint)_`from api.tests.abstract.test_metadata_functional import MetadataAttributesFunctional`
+
+    - _Functional test cases_ _(Only required if model has nav menu entry)_`from api.tests.abstract.test_metadata_functional import MetaDataNavigationEntriesFunctional`
+
 - View Added to Navigation
 
 


### PR DESCRIPTION
ref: #414

### :books: Summary
<!-- your summary here emojis ref: https://github.com/yodamad/gitlab-emoji -->



### :link: Links / References
<!-- 

    using a list as any links to other references or links as required. if relevant, describe the link/reference

    Include any issues or related merge requests. Note: dependent MR's also to be added to "Merge request dependencies"

-->

- [ ] Related: #414

### :construction_worker: Tasks

 - [ ] Add your tasks here if required (delete)

<!-- dont remove tasks below strike through including the checkbox by enclosing in double tidle '~~' -->

- [ ] :firecracker: Contains breaking-change Any Breaking change(s)?

    _Breaking Change must also be notated in the commit that introduces it and in [Conventional Commit Format](https://www.conventionalcommits.org/en/v1.0.0/)._

    - [ ] :notebook: Release notes updated

- [x] :blue_book: Documentation written

    _All features to be documented within the correct section(s). Administration, Development and/or User_

- [ ] :checkered_flag: Milestone assigned

- [x] :gear: :test_tube: [Functional Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

- [ ] :test_tube: [Unit Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

    _ensure test coverage delta is not less than zero_

- [ ] :page_facing_up: Roadmap updated
