### PR TITLE
feat(api): Always use a models `View` serializer for the response

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -301,6 +301,8 @@ if API_ENABLED:
 
 Centurion ERP's API is versioned, with [v1 Depreciated](/api/swagger) and [v2 as the current](/api/v2/docs).
 
+For CRUD actions `Add`, `update` and `replace` the serializer that returns is the Models `View` serializer.
+
 **Note:** _API v2 is currently in beta phase. AS such is subject to change. When the new UI ius released, API v2 will move to stable._
 
 ## Authentication

--- a/app/core/viewsets/ticket.py
+++ b/app/core/viewsets/ticket.py
@@ -353,3 +353,24 @@ class TicketViewSet(ModelViewSet):
             self.serializer_class = globals()[serializer_prefix + 'TicketModelSerializer']
 
         return self.serializer_class
+
+
+    def get_view_serializer_name(self) -> str:
+        """Get the Models `View` Serializer name.
+
+        Override this function if required and/or the serializer names deviate from default.
+
+        Returns:
+            str: Models View Serializer Class name
+        """
+
+        if self.view_serializer_name is None:
+
+            self.view_serializer_name = super().get_view_serializer_name()
+
+            for remove_str in [ 'ChangeTicketView', 'AddTicketView', 'ImportTicketView', 'TriageTicketView' ]:
+
+                self.view_serializer_name = self.view_serializer_name.replace(remove_str, 'TicketView')
+
+
+        return self.view_serializer_name

--- a/app/core/viewsets/ticket_comment.py
+++ b/app/core/viewsets/ticket_comment.py
@@ -370,3 +370,25 @@ class ViewSet(ModelViewSet):
             return "Ticket Comment"
         
         return 'Ticket Comments'
+
+
+
+    def get_view_serializer_name(self) -> str:
+        """Get the Models `View` Serializer name.
+
+        Override this function if required and/or the serializer names deviate from default.
+
+        Returns:
+            str: Models View Serializer Class name
+        """
+
+        if self.view_serializer_name is None:
+
+            self.view_serializer_name = super().get_view_serializer_name()
+
+            for remove_str in [ 'Add', 'Change', 'Import', 'Triage', 'ITIL', 'FollowUp', 'Solution', 'Task' ]:
+
+                self.view_serializer_name = self.view_serializer_name.replace(remove_str, '')
+
+
+        return self.view_serializer_name

--- a/app/itam/viewsets/device_software.py
+++ b/app/itam/viewsets/device_software.py
@@ -214,3 +214,31 @@ class ViewSet( ModelViewSet ):
             ]
 
         return table_fields
+
+
+
+    def get_view_serializer_name(self) -> str:
+        """Get the Models `View` Serializer name.
+
+        Override this function if required and/or the serializer names deviate from default.
+
+        Returns:
+            str: Models View Serializer Class name
+        """
+
+        if self.view_serializer_name is None:
+
+            self.view_serializer_name = super().get_view_serializer_name()
+
+            for remove_str in [ 'SoftwareInstalls' ]:
+
+                self.view_serializer_name = self.view_serializer_name.replace(remove_str, 'DeviceSoftware')
+
+
+        return self.view_serializer_name
+    # Device,
+    # DeviceSoftware,
+    # DeviceSoftwareModelSerializer,
+    # DeviceSoftwareViewSerializer,
+    # Software,
+    # SoftwareInstallsModelSerializer,


### PR DESCRIPTION
### :books: Summary
<!-- your summary here emojis ref: https://github.com/yodamad/gitlab-emoji -->



### :link: Links / References
<!-- 

    using a list as any links to other references or links as required. if relevant, describe the link/reference

    Include any issues or related merge requests. Note: dependent MR's also to be added to "Merge request dependencies"

-->

- Closes: #578

### :construction_worker: Tasks

 - [ ] Add your tasks here if required (delete)

<!-- dont remove tasks below strike through including the checkbox by enclosing in double tidle '~~' -->

 - [ ] **Feature Release ONLY** :red_square: Squash migration files :red_square: 
    _Multiple migration files created as part of this release are to be sqauashed into a few files as possible so as to limit the number of migrations_ 

- [ ] :firecracker: Contains breaking-change Any Breaking change(s)?

    _Breaking Change must also be notated in the commit that introduces it and in [Conventional Commit Format](https://www.conventionalcommits.org/en/v1.0.0/)._

    - [ ] :notebook: Release notes updated

- [ ] :blue_book: Documentation written

    _All features to be documented within the correct section(s). Administration, Development and/or User_

- [ ] :checkered_flag: Milestone assigned

- [ ] :gear: :test_tube: [Functional Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

- [ ] :test_tube: [Unit Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

    _ensure test coverage delta is not less than zero_

- [ ] :page_facing_up: Roadmap updated
