### PR TITLE
feat(python): update social-auth-app-django 5.4.1 -> 5.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django==5.1.13
 django-cors-headers==4.4.0
 
 django-debug-toolbar==5.1.0
-social-auth-app-django==5.4.1
+social-auth-app-django==5.6.0
 
 djangorestframework==3.16.0
 djangorestframework-jsonapi==7.1.0


### PR DESCRIPTION
replaces #1020