### PR TITLE
feat(api): Update HTTP Header `Allow` based off of user permissions

### DIFF
--- a/app/access/permissions/super_user.py
+++ b/app/access/permissions/super_user.py
@@ -1,5 +1,4 @@
 from rest_framework.exceptions import (
-    MethodNotAllowed,
     NotAuthenticated,
 )
 
@@ -25,11 +24,6 @@ class SuperUserPermissions(
             raise NotAuthenticated(
                 code = 'anonymouse_user'
             )
-
-
-        if request.method not in view.allowed_methods:
-
-            raise MethodNotAllowed(method = request.method)
 
 
         if request.user.is_superuser:

--- a/app/access/permissions/super_user.py
+++ b/app/access/permissions/super_user.py
@@ -19,6 +19,13 @@ class SuperUserPermissions(
 
     def has_permission(self, request, view):
 
+        self._view_allowed_methods = getattr(view, 'allowed_methods', {})
+
+        view.permissions_required = self.get_required_permissions(
+            method = request.method,
+            model_cls = view.model
+        )
+
         if request.user.is_anonymous:
 
             raise NotAuthenticated(
@@ -28,7 +35,7 @@ class SuperUserPermissions(
 
         if request.user.is_superuser:
 
-            return True
+            return self.permission_allowed_finaliser(view)
 
 
         return False

--- a/app/access/permissions/tenancy.py
+++ b/app/access/permissions/tenancy.py
@@ -1,7 +1,6 @@
 import traceback
 
 from rest_framework.exceptions import (
-    MethodNotAllowed,
     NotAuthenticated,
     ParseError,
     PermissionDenied
@@ -218,8 +217,8 @@ class TenancyPermissions(
 
         try:
 
+            self._view_perms_map = getattr(view, 'perms_map', {})
 
-            self._perms_map = getattr(view, 'perms_map', {})
 
             view.permissions_required = self.get_required_permissions(
                 method = request.method,
@@ -233,10 +232,29 @@ class TenancyPermissions(
                 )
 
 
-            if request.method not in view.allowed_methods:
+            kwargs = {
+                'app_label': view.model._meta.app_label,
+                'model_name': view.model._meta.model_name
+            }
 
-                raise MethodNotAllowed(method = request.method)
+            _perms_map = {    # Expand variables
+                    method: [
+                        perm % kwargs for perm in perms
+                            if request.user.has_perm(
+                                permission = perm % kwargs,
+                                tenancy_permission = False,
+                            )
+                    ]
+                        for method, perms in self.perms_map.items()
+            }
 
+            view.allowed_methods = [
+                method for method in view.allowed_methods
+                    if _perms_map.get(method, None)
+            ]
+
+            # Update AllowedMthods header as it may have changed
+            view.headers = view.default_response_headers
 
             if not request.user.has_perms(
                 permission_list = view.permissions_required,

--- a/app/access/permissions/tenancy.py
+++ b/app/access/permissions/tenancy.py
@@ -219,11 +219,7 @@ class TenancyPermissions(
 
             self._view_perms_map = getattr(view, 'perms_map', {})
 
-
-            view.permissions_required = self.get_required_permissions(
-                method = request.method,
-                model_cls = view.model
-            )
+            self._view_allowed_methods = getattr(view, 'allowed_methods', {})
 
             if request.user.is_anonymous:
 
@@ -232,24 +228,11 @@ class TenancyPermissions(
                 )
 
 
-            kwargs = {
-                'app_label': view.model._meta.app_label,
-                'model_name': view.model._meta.model_name
-            }
+            view.permissions_required = self.get_required_permissions(
+                method = request.method,
+                model_cls = view.model
+            )
 
-            _perms_map = {    # Expand variables
-                    method: [
-                        perm % kwargs for perm in perms
-                    ]
-                        for method, perms in self.perms_map.items()
-            }
-
-            view.allowed_methods = [
-                method for method in view.allowed_methods
-                    if request.user.has_perms(
-                        permission_list = _perms_map.get(method, None),
-                    )
-            ]
 
             # Update AllowedMthods header as it may have changed
             view.headers = view.default_response_headers
@@ -285,7 +268,10 @@ class TenancyPermissions(
                 and view.action in [ 'metadata', 'list' ]
             ):
 
-                return True
+                return self.permission_allowed_finaliser(
+                    view,
+                    user = request.user
+                )
 
             elif(
                 request.user.has_perms(
@@ -294,7 +280,10 @@ class TenancyPermissions(
                 and not self.is_tenancy_model(view)
             ):
 
-                return True
+                return self.permission_allowed_finaliser(
+                    view,
+                    user = request.user
+                )
 
             elif(
                 request.user.has_perms(
@@ -305,7 +294,10 @@ class TenancyPermissions(
                 and obj_organization is not None
             ):
 
-                return True
+                return self.permission_allowed_finaliser(
+                    view,
+                    user = request.user
+                )
 
             elif(
                 request.user.has_perms(
@@ -316,7 +308,10 @@ class TenancyPermissions(
                 and obj_organization is not None
             ):
 
-                return True
+                return self.permission_allowed_finaliser(
+                    view,
+                    user = request.user
+                )
 
 
             raise PermissionDenied(

--- a/app/access/permissions/tenancy.py
+++ b/app/access/permissions/tenancy.py
@@ -240,17 +240,15 @@ class TenancyPermissions(
             _perms_map = {    # Expand variables
                     method: [
                         perm % kwargs for perm in perms
-                            if request.user.has_perm(
-                                permission = perm % kwargs,
-                                tenancy_permission = False,
-                            )
                     ]
                         for method, perms in self.perms_map.items()
             }
 
             view.allowed_methods = [
                 method for method in view.allowed_methods
-                    if _perms_map.get(method, None)
+                    if request.user.has_perms(
+                        permission_list = _perms_map.get(method, None),
+                    )
             ]
 
             # Update AllowedMthods header as it may have changed

--- a/app/access/permissions/user.py
+++ b/app/access/permissions/user.py
@@ -19,6 +19,8 @@ class UserPermissions(
 
     def has_permission(self, request, view):
 
+        self._view_allowed_methods = getattr(view, 'allowed_methods', {})
+
         if request.user.is_anonymous:
 
             raise NotAuthenticated(
@@ -33,15 +35,24 @@ class UserPermissions(
 
         if view.action in [ 'create' ]:
 
-            return True
+            return self.permission_allowed_finaliser(
+                view,
+                user = request.user
+            )
 
         elif view.action in [ 'list', 'metadata' ]:
 
-            return True
+            return self.permission_allowed_finaliser(
+                view,
+                user = request.user
+            )
 
         elif view.action in [ 'retrieve', 'destroy', 'partial_update', 'update' ]:
 
-            return True
+            return self.permission_allowed_finaliser(
+                view,
+                user = request.user
+            )
 
 
         return False

--- a/app/access/tests/unit/permission_tenancy/test_unit_tenancy_permission.py
+++ b/app/access/tests/unit/permission_tenancy/test_unit_tenancy_permission.py
@@ -394,6 +394,69 @@ class TenancyPermissionsTestCases(
 
 
 
+    def test_function_called_permission_allowed_finaliser(self, viewset, mocker,
+        parameterized, param_key_users,
+        param_not_used, param_request_method, param_raised_exception, param_object_tenancy,
+        param_user_tenancy,param_required_permission, param_user_permissions, param_is_superuser,
+        param_is_tenancy_model, param_kwargs, param_exec_code
+    ):
+        """Test Function called
+
+        Ensure that fn `permission_allowed_finaliser` is called for user with
+        permission.
+        """
+
+
+        mocker.patch.object(
+            viewset.permission_classes[0], 'is_tenancy_model',
+            return_value = param_is_tenancy_model
+        )
+        mocker.patch.object(
+            viewset.permission_classes[0], 'get_tenancy',
+            return_value = param_object_tenancy
+        )
+
+        view = viewset(
+            kwargs = param_kwargs,
+            method = param_request_method,
+            obj_organization = param_object_tenancy,
+            permission_required = param_required_permission,
+            user = MockUser(
+                is_anonymous = False,
+                is_superuser = param_is_superuser,
+                tenancy = param_user_tenancy,
+                permissions = param_user_permissions,
+            )
+        )
+
+        mocker.patch('rest_framework.permissions.DjangoModelPermissions.get_required_permissions', return_value = [ param_required_permission ] )
+
+        view.allowed_methods = [ param_request_method ]
+
+        finaliser = mocker.spy(view.permission_classes[0],'permission_allowed_finaliser')
+
+        view.permission_classes[0]().has_permission(request = view.request, view = view)
+
+        if param_raised_exception is None:
+
+            finaliser.assert_called_once()
+            
+
+        else:
+            finaliser.assert_not_called()
+
+            # not called
+
+        # if param_raised_exception:
+
+        #     assert not view.permission_classes[0]().has_permission(request = view.request, view = view)
+
+        # else:
+
+        #     assert view.permission_classes[0]().has_permission(request = view.request, view = view)
+
+
+
     @property
     def parameterized_object(self) -> dict:
 

--- a/app/access/tests/unit/permissions/test_unit_super_user_permission.py
+++ b/app/access/tests/unit/permissions/test_unit_super_user_permission.py
@@ -120,3 +120,66 @@ class SuperUserPermissionPyTest(
                 is_superuser = True
             )
         )
+
+
+
+    def test_function_called_permission_allowed_finaliser_has_permission(self, mocker,
+        viewset,
+    ):
+
+        permission_required = 'boo'
+
+        view = viewset.__class__(
+            method = 'GET',
+            kwargs = {},
+            permission_required = permission_required,
+            obj_organization = 1,
+            user = MockUser(
+                is_anonymous = False,
+                is_superuser = True,
+                permissions = [ permission_required ],
+                tenancy = 1,
+            )
+        )
+
+        view.get_log = None
+        mocker.patch.object(view, 'get_log')
+
+        mocker.patch('rest_framework.permissions.DjangoModelPermissions.get_required_permissions', return_value = [ permission_required ] )
+
+        finaliser = mocker.spy(view.permission_classes[0],'permission_allowed_finaliser')
+
+        view.permission_classes[0]().has_permission(
+            request = view.request,
+            view = view
+        )
+
+        finaliser.assert_called_once()
+
+
+    def test_function_called_permission_allowed_finaliser_anon_denied(self, mocker,
+        viewset,
+    ):
+
+        view = viewset.__class__(
+            method = 'GET',
+            kwargs = {},
+            user = MockUser(
+                is_anonymous = True,
+                is_superuser = True
+            )
+        )
+
+        view.get_log = None
+        mocker.patch.object(view, 'get_log')
+
+        finaliser = mocker.spy(view.permission_classes[0],'permission_allowed_finaliser')
+
+        with pytest.raises( NotAuthenticated ):
+
+            view.permission_classes[0]().has_permission(
+                request = view.request,
+                view = view
+            )
+
+        finaliser.assert_not_called()

--- a/app/access/tests/unit/permissions/test_unit_user_permission.py
+++ b/app/access/tests/unit/permissions/test_unit_user_permission.py
@@ -129,3 +129,67 @@ class UserPermissionPyTest(
                 is_anonymous = False
             )
         )
+
+
+
+
+    def test_function_called_permission_allowed_finaliser_has_permission(self, mocker,
+        viewset,
+    ):
+
+        permission_required = 'boo'
+
+        view = viewset.__class__(
+            method = 'GET',
+            kwargs = {},
+            permission_required = permission_required,
+            obj_organization = 1,
+            user = MockUser(
+                is_anonymous = False,
+                is_superuser = False,
+                permissions = [ permission_required ],
+                tenancy = 1,
+            )
+        )
+
+        view.get_log = None
+        mocker.patch.object(view, 'get_log')
+
+        mocker.patch('rest_framework.permissions.DjangoModelPermissions.get_required_permissions', return_value = [ permission_required ] )
+
+        finaliser = mocker.spy(view.permission_classes[0],'permission_allowed_finaliser')
+
+        view.permission_classes[0]().has_permission(
+            request = view.request,
+            view = view
+        )
+
+        finaliser.assert_called_once()
+
+
+    def test_function_called_permission_allowed_finaliser_anon_denied(self, mocker,
+        viewset,
+    ):
+
+        view = viewset.__class__(
+            method = 'GET',
+            kwargs = {},
+            user = MockUser(
+                is_anonymous = True,
+                is_superuser = False
+            )
+        )
+
+        view.get_log = None
+        mocker.patch.object(view, 'get_log')
+
+        finaliser = mocker.spy(view.permission_classes[0],'permission_allowed_finaliser')
+
+        with pytest.raises( NotAuthenticated ):
+
+            view.permission_classes[0]().has_permission(
+                request = view.request,
+                view = view
+            )
+
+        finaliser.assert_not_called()

--- a/app/api/permissions/common.py
+++ b/app/api/permissions/common.py
@@ -13,56 +13,77 @@ class CenturionModelPermissions(
     This is the base class for model permissions within Centurion.
     """
 
+    _perms_map: dict[str, list[str]] | None = None
+
+    _view_perms_map: dict[str, list[str]] | None = None
+
 
     @property
     def perms_map(self) -> dict[str, list[str]]:
 
-        default: dict[str, list[str]] = {
-            'GET': [
-                '%(app_label)s.view_%(model_name)s',
-                *getattr(self, '_perms_map', {}).get(
-                    'GET', []
-                )
-            ],
-            'OPTIONS': [
-                '%(app_label)s.view_%(model_name)s',
-                *getattr(self, '_perms_map', {}).get(
-                    'OPTIONS', []
-                )
-            ],
-            'HEAD': [
-                '%(app_label)s.view_%(model_name)s',
-                *getattr(self, '_perms_map', {}).get(
-                    'HEAD', []
-                )
-            ],
-            'POST': [
-                '%(app_label)s.add_%(model_name)s',
-                *getattr(self, '_perms_map', {}).get(
-                    'POST', []
-                )
-            ],
-            'PUT': [
-                '%(app_label)s.change_%(model_name)s',
-                *getattr(self, '_perms_map', {}).get(
-                    'PUT', []
-                )
-            ],
-            'PATCH': [
-                '%(app_label)s.change_%(model_name)s',
-                *getattr(self, '_perms_map', {}).get(
-                    'PATCH', []
-                )
-            ],
-            'DELETE': [
-                '%(app_label)s.delete_%(model_name)s',
-                *getattr(self, '_perms_map', {}).get(
-                    'DELETE', []
-                )
-            ],
-        }
 
-        return default
+        if self._perms_map is None:
+
+            self._perms_map = {
+                'GET': [
+                    '%(app_label)s.view_%(model_name)s',
+                    *(
+                        getattr(self, '_view_perms_map', {}).get('GET', [] )
+                        if self._view_perms_map is not None
+                        else []
+                    )
+                ],
+                'OPTIONS': [
+                    '%(app_label)s.view_%(model_name)s',
+                    *(
+                        getattr(self, '_view_perms_map', {}).get('OPTIONSGET', [] )
+                        if self._view_perms_map is not None
+                        else []
+                    )
+                ],
+                'HEAD': [
+                    '%(app_label)s.view_%(model_name)s',
+                    *(
+                        getattr(self, '_view_perms_map', {}).get('HEAD', [] )
+                        if self._view_perms_map is not None
+                        else []
+                    )
+                ],
+                'POST': [
+                    '%(app_label)s.add_%(model_name)s',
+                    *(
+                        getattr(self, '_view_perms_map', {}).get('POST', [] )
+                        if self._view_perms_map is not None
+                        else []
+                    )
+                ],
+                'PUT': [
+                    '%(app_label)s.change_%(model_name)s',
+                    *(
+                        getattr(self, '_view_perms_map', {}).get('PUT', [] )
+                        if self._view_perms_map is not None
+                        else []
+                    )
+                ],
+                'PATCH': [
+                    '%(app_label)s.change_%(model_name)s',
+                    *(
+                        getattr(self, '_view_perms_map', {}).get('PATCH', [] )
+                        if self._view_perms_map is not None
+                        else []
+                    )
+                ],
+                'DELETE': [
+                    '%(app_label)s.delete_%(model_name)s',
+                    *(
+                        getattr(self, '_view_perms_map', {}).get('DELETE', [] )
+                        if self._view_perms_map is not None
+                        else []
+                    )
+                ],
+            }
+
+        return self._perms_map
 
 
 

--- a/app/api/permissions/common.py
+++ b/app/api/permissions/common.py
@@ -17,9 +17,18 @@ class CenturionModelPermissions(
 
     _view_perms_map: dict[str, list[str]] | None = None
 
+    _view_allowed_methods = []
+    """Allowed Methods from ViewSet
+
+    This property must be set during init.
+    """
+
 
     @property
     def perms_map(self) -> dict[str, list[str]]:
+
+        if len(self._view_allowed_methods) == 0:
+            raise ValueError('cls._view_allowed_methods must contain the views methods.')
 
 
         if self._perms_map is None:
@@ -83,8 +92,56 @@ class CenturionModelPermissions(
                 ],
             }
 
+            self._perms_map = { method: self._perms_map[method] for method in self._view_allowed_methods }
+
         return self._perms_map
 
+
+    def permission_allowed_finaliser(self, view, user = None ) -> bool:
+        """Perform any final actions
+
+        Intent for this fn is that any final actions to be conducted prior
+        to exiting/leaving the permission class.
+
+        Args:
+            view (ViewSet): ViewSet to be updated.
+            user (CenturionUser): Update the allowed_methods to match the users
+                 permissions.
+
+        Returns:
+            True (bool): Always returns true.
+        """
+
+
+        kwargs = {
+            'app_label': view.model._meta.app_label,
+            'model_name': view.model._meta.model_name
+        }
+
+        _perms_map = {    # Expand variables
+                method: [
+                    perm % kwargs for perm in perms
+                ]
+                    for method, perms in self.perms_map.items()
+        }
+
+        if user:
+
+            view.allowed_methods = [
+                method for method in view.allowed_methods
+                    if user.has_perms(
+                        permission_list = _perms_map.get(method, None),
+                    )
+            ]
+
+        else:
+
+            view.allowed_methods = [
+                method for method in view.allowed_methods
+                    if _perms_map.get(method, None) is not None
+            ]
+
+        return True
 
 
     def has_permission(self, request, view):

--- a/app/api/permissions/common.py
+++ b/app/api/permissions/common.py
@@ -36,7 +36,7 @@ class CenturionModelPermissions(
                 'OPTIONS': [
                     '%(app_label)s.view_%(model_name)s',
                     *(
-                        getattr(self, '_view_perms_map', {}).get('OPTIONSGET', [] )
+                        getattr(self, '_view_perms_map', {}).get('OPTIONS', [] )
                         if self._view_perms_map is not None
                         else []
                     )

--- a/app/api/tests/functional/test_functional_common_viewset.py
+++ b/app/api/tests/functional/test_functional_common_viewset.py
@@ -254,6 +254,8 @@ class CommonViewSetTestCases:
 
         viewset.action = 'list'
 
+        viewset.allowed_methods = [ 'GET' ]
+
         if not viewset.model:
             pytest.xfail( reason = 'no model exists, assuming viewset is a base/mixin viewset.' )
 
@@ -265,10 +267,7 @@ class CommonViewSetTestCases:
                 permission_class = permission_class.op1_class
 
 
-            viewset.permissions_required = permission_class().get_required_permissions(
-                method = 'GET',
-                model_cls = model
-            )
+            permission_class().has_permission(request = viewset.request, view = viewset)
 
         queryset = viewset.get_queryset()
 

--- a/app/api/tests/unit/permissions/test_unit_common_model_permission.py
+++ b/app/api/tests/unit/permissions/test_unit_common_model_permission.py
@@ -5,6 +5,10 @@ from unittest.mock import PropertyMock
 from pytest_simplified.suites.attributes import ClassAttributesTestCases
 from pytest_simplified.suites.functions import ClassFunctionsTestCases
 
+from rest_framework.exceptions import (
+    NotAuthenticated,
+)
+
 from api.permissions.common import (
     CenturionModelPermissions,
 )
@@ -239,6 +243,88 @@ class CenturionModelPermissionTestCases(
         assert issubclass(test_class, CenturionModelPermissions)
 
 
+
+    def test_function_called_permission_allowed_finaliser_has_permission(self, mocker,
+        viewset,
+    ):
+        """Test Function called
+
+        Ensure that fn `permission_allowed_finaliser` is called for user with
+        permission.
+        """
+
+        mocker.patch.object(
+            viewset.permission_classes[0], 'is_tenancy_model',
+            return_value = True
+        )
+        mocker.patch.object(
+            viewset.permission_classes[0], 'get_tenancy',
+            return_value = 1
+        )
+
+        permission_required = 'boo'
+
+        view = viewset(
+            method = 'GET',
+            kwargs = {},
+            permission_required = permission_required,
+            obj_organization = 1,
+            user = MockUser(
+                is_anonymous = False,
+                is_superuser = False,
+                permissions = [ permission_required ],
+                tenancy = 1,
+            )
+        )
+
+        view.get_log = None
+        mocker.patch.object(view, 'get_log')
+
+        mocker.patch('rest_framework.permissions.DjangoModelPermissions.get_required_permissions', return_value = [ permission_required ] )
+
+        finaliser = mocker.spy(view.permission_classes[0],'permission_allowed_finaliser')
+
+        view.permission_classes[0]().has_permission(
+            request = view.request,
+            view = view
+        )
+
+        finaliser.assert_called_once()
+
+
+    def test_function_called_permission_allowed_finaliser_anon_denied(self, mocker,
+        viewset,
+    ):
+        """Test Function called
+
+        Ensure that fn `permission_allowed_finaliser` is Not called for anon
+        user, as they should be denied access.
+        """
+
+        view = viewset(
+            method = 'GET',
+            kwargs = {},
+            user = MockUser(
+                is_anonymous = True,
+                is_superuser = False
+            )
+        )
+
+        view.get_log = None
+        mocker.patch.object(view, 'get_log')
+
+        finaliser = mocker.spy(view.permission_classes[0],'permission_allowed_finaliser')
+
+        with pytest.raises( NotAuthenticated ):
+
+            view.permission_classes[0]().has_permission(
+                request = view.request,
+                view = view
+            )
+
+        finaliser.assert_not_called()
+
+
     def test_function_has_permission_no_call_is_superuser(self, viewset, mocker):
         """Test Function
 
@@ -320,3 +406,11 @@ class CenturionModelPermissionPyTest(
     @pytest.mark.xfail( reason = 'Common permissions raises notimplemented exception. Test is N/A.' )
     def test_function_has_permission_no_call_is_superuser(self, viewset, mocker):
         assert False
+
+
+    def test_function_called_permission_allowed_finaliser_has_permission(self):
+        pytest.xfail( reason = 'test is N/A for base class.')
+
+
+    def test_function_called_permission_allowed_finaliser_anon_denied(self):
+        pytest.xfail( reason = 'test is N/A for base class.')

--- a/app/api/tests/unit/permissions/test_unit_common_model_permission.py
+++ b/app/api/tests/unit/permissions/test_unit_common_model_permission.py
@@ -115,6 +115,16 @@ class MockLogger:
 
 class MyMockView:
 
+    default_response_headers = [
+        'DELETE',
+        'GET',
+        'HEAD',
+        'OPTIONS',
+        'PATCH',
+        'POST',
+        'PUT'
+    ]
+
     class MockModel:
 
         class Meta:

--- a/app/api/tests/unit/permissions/test_unit_common_object_permission.py
+++ b/app/api/tests/unit/permissions/test_unit_common_object_permission.py
@@ -141,3 +141,11 @@ class CenturionObjectPermissionPyTest(
     @pytest.mark.xfail( reason = 'Common permissions raises notimplemented exception. Test is N/A.' )
     def test_function_has_object_permission_no_call_is_superuser(self):
         assert False
+
+
+    def test_function_called_permission_allowed_finaliser_has_permission(self):
+        pytest.xfail( reason = 'test is N/A for base class.')
+
+
+    def test_function_called_permission_allowed_finaliser_anon_denied(self):
+        pytest.xfail( reason = 'test is N/A for base class.')

--- a/app/api/tests/unit/permissions/test_unit_default_permission.py
+++ b/app/api/tests/unit/permissions/test_unit_default_permission.py
@@ -62,3 +62,11 @@ class DefaultDenyPermissionPyTest(
                 is_superuser = True
             )
         )
+
+
+    def test_function_called_permission_allowed_finaliser_has_permission(self):
+        pytest.xfail( reason = 'test is N/A for base class.')
+
+
+    def test_function_called_permission_allowed_finaliser_anon_denied(self):
+        pytest.xfail( reason = 'test is N/A for base class.')

--- a/app/api/viewsets/common/common.py
+++ b/app/api/viewsets/common/common.py
@@ -563,18 +563,51 @@ class CommonViewSet(
 
 
 
+    _viewset_allowed_methods: list[str] | None = None
+    """Allowed HTTP Methods
+    
+    Initially set to match the value of the default Django method
+    `_allowed_methods`.
+    If the allowed methods for the viewset require modification, use the
+    `allowed_methods` setter. i.e. `allowed_methods = ['POST', 'PATCH']`
+    """
+
+
+    def _allowed_methods(self) -> list[str]:
+        """Override Base
+
+        Overrides the base function of the same name. THis exists so that
+        the HTTP methods allowed can be customised.
+        """
+
+        if self._viewset_allowed_methods is None:    # set to base default
+
+            self._viewset_allowed_methods = [
+                m.upper() for m in self.http_method_names if hasattr(self, m)
+            ]
+
+        return self._viewset_allowed_methods
+
 
     @property
-    def allowed_methods(self):
+    def allowed_methods(self) -> list[str]:
         """Allowed HTTP Methods
 
-        _Optional_, HTTP Methods allowed for the `viewSet`.
+        Init the default function of the same name.
 
-        Returns:
-            list: Allowed HTTP Methods
+        Initialising the default method enables the default "featurre set"
+        to still be utilised.
         """
 
         return super().allowed_methods
+
+
+    @allowed_methods.setter
+    def allowed_methods(self, value) -> None:
+
+        self._viewset_allowed_methods = value
+
+        super().allowed_methods
 
 
     back_url: str = None

--- a/app/core/tests/functional/additional_ticketcommentaction_permissions_api.py
+++ b/app/core/tests/functional/additional_ticketcommentaction_permissions_api.py
@@ -1,27 +1,84 @@
 import pytest
-import random
 
 from django.test import Client
-from django.urls.exceptions import NoReverseMatch
-
-from rest_framework.permissions import (
-    IsAuthenticatedOrReadOnly
-)
-
-from centurion_feature_flag.lib.feature_flag import CenturionFeatureFlagging
 
 
 
 class AdditionalTestCases:
 
 
+
+    @pytest.mark.xfail( reason = 'User requires import permission for add action comment' )
+    def test_api_add_exception(self, mocker, model_instance,
+        parameterized, param_key_exceptions, param_value,
+        param_exception, param_http_status,
+        api_request_permissions, model_kwargs, kwargs_api_create, model
+    ):
+
+        try:
+
+            client = Client()
+
+            client.force_login( api_request_permissions['user']['add'] )
+
+
+            kwargs = model_kwargs()
+            kwargs.update({
+                'organization': api_request_permissions['tenancy']['user']
+            })
+
+            the_model = model_instance( kwargs_create = kwargs )
+
+            url = the_model.get_url( many = True )
+
+            kwargs_create = kwargs_api_create.copy()
+            kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+            kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+            mocker.patch(
+                "access.managers.tenancy.TenancyManager.create",
+                side_effect = param_exception("an integrity error occured....")
+            )
+
+
+            response = client.post(
+                path = url,
+                data = kwargs_create,
+                content_type = 'application/json'
+            )
+
+
+            assert response.status_code == param_http_status, response.content
+
+        except AssertionError as ex:
+            pytest.xfail(
+                reason = (
+                    'User requires import permission for add action comment, '
+                    f'failure=[{ex}]'
+                )
+            )
+
+
+
+    @pytest.mark.skip( reason = 'ToDo: Write test case' )
+    def test_api_add_exception_import_user(self, mocker, model_instance,
+        parameterized, param_key_exceptions, param_value,
+        param_exception, param_http_status,
+        api_request_permissions, model_kwargs, kwargs_api_create, model
+    ):
+        """ API action capture exception
+
+        Ensure that during a `Create` operation that the exception is captured
+        and that the correct http status code is returned
+        """
+        pass
+
+
+
+    @pytest.mark.xfail( reason = 'Only import user can add an action comment' )
     def test_permission_add(self, model_instance, api_request_permissions,
         model_kwargs, kwargs_api_create,
     ):
-        """ Check correct permission for add 
-
-        Attempt to add as user with permission
-        """
 
         client = Client()
 
@@ -37,71 +94,26 @@ class AdditionalTestCases:
 
         url = the_model.get_url( many = True )
 
-        # the_model.delete()
-
         kwargs_create = kwargs_api_create.copy()
-        # kwargs_create['model'] = the_model.model.id
         kwargs_create['created_by'] = api_request_permissions['user']['add'].id
         kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
 
 
-        try:
-
-            response = client.post(
-                path = url,
-                data = kwargs_create,
-                content_type = 'application/json'
-            )
-
-        except NoReverseMatch:
-
-            # Cater for models that use viewset `-list` but `-detail`
-            try:
-
-                response = client.post(
-                    path = the_model.get_url( many = False ),
-                    data = kwargs_create
-                )
-
-            except NoReverseMatch:
-
-                pass
-
-
-        if response.status_code == 405:
-            pytest.xfail( reason = 'ViewSet does not have this request method.' )
-
-        assert response.status_code == 201, response.content
-
-
-
-    def test_permission_change(self, model_instance, api_request_permissions, model_kwargs,
-    ):
-        """ Check correct permission for change
-
-        Make change with user who has change permission
-        """
-
-        client = Client()
-
-        client.force_login( api_request_permissions['user']['change'] )
-
-        kwargs = model_kwargs()
-        kwargs.update({
-            'organization': api_request_permissions['tenancy']['user']
-        })
-
-        change_item = model_instance(
-            kwargs_create = kwargs,
-        )
-
-        response = client.patch(
-            path = change_item.get_url( many = False ),
-            data = self.change_data,
+        response = client.post(
+            path = url,
+            data = kwargs_create,
             content_type = 'application/json'
         )
 
-        if response.status_code == 405:
-            pytest.xfail( reason = 'ViewSet does not have this request method.' )
+        assert response.status_code == 201, response.content\
 
-        assert response.status_code == 200, response.content
+
+    @pytest.mark.skip( reason = 'ToDo: Write test case' )
+    def test_permission_add_import_user(self, model_instance, api_request_permissions,
+        model_kwargs, kwargs_api_create,
+    ):
+        """ Check correct permission for add 
+
+        Attempt to add as user with "import" permission
+        """
+        pass

--- a/app/core/tests/functional/additional_ticketcommentaction_permissions_api.py
+++ b/app/core/tests/functional/additional_ticketcommentaction_permissions_api.py
@@ -7,7 +7,6 @@ from django.test import Client
 class AdditionalTestCases:
 
 
-
     @pytest.mark.xfail( reason = 'User requires import permission for add action comment' )
     def test_api_add_exception(self, mocker, model_instance,
         parameterized, param_key_exceptions, param_value,
@@ -60,18 +59,61 @@ class AdditionalTestCases:
 
 
 
-    @pytest.mark.skip( reason = 'ToDo: Write test case' )
     def test_api_add_exception_import_user(self, mocker, model_instance,
         parameterized, param_key_exceptions, param_value,
         param_exception, param_http_status,
-        api_request_permissions, model_kwargs, kwargs_api_create, model
+        api_request_permissions, model_kwargs, kwargs_api_create, model,
+        model_contenttype
     ):
         """ API action capture exception
 
         Ensure that during a `Create` operation that the exception is captured
         and that the correct http status code is returned
         """
-        pass
+
+        user_role = api_request_permissions['user']['add'].groups.all(
+        )[0].roles.all()[0]
+
+        import_permission = model_contenttype.objects.get_for_model(
+            model
+        ).permission_set.get(
+            codename = f"import_{model._meta.model_name}"
+        )
+
+        user_role.permissions.add(import_permission)
+
+
+        client = Client()
+
+        client.force_login( api_request_permissions['user']['add'] )
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+        url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+        mocker.patch(
+            "access.managers.tenancy.TenancyManager.create",
+            side_effect = param_exception("an integrity error occured....")
+        )
+
+
+        response = client.post(
+            path = url,
+            data = kwargs_create,
+            content_type = 'application/json'
+        )
+
+
+        assert response.status_code == param_http_status, response.content
 
 
 
@@ -108,12 +150,50 @@ class AdditionalTestCases:
         assert response.status_code == 201, response.content\
 
 
-    @pytest.mark.skip( reason = 'ToDo: Write test case' )
+
     def test_permission_add_import_user(self, model_instance, api_request_permissions,
-        model_kwargs, kwargs_api_create,
+        model_kwargs, kwargs_api_create, model, model_contenttype
     ):
         """ Check correct permission for add 
 
         Attempt to add as user with "import" permission
         """
-        pass
+
+        user_role = api_request_permissions['user']['add'].groups.all(
+        )[0].roles.all()[0]
+
+        import_permission = model_contenttype.objects.get_for_model(
+            model
+        ).permission_set.get(
+            codename = f"import_{model._meta.model_name}"
+        )
+
+        user_role.permissions.add(import_permission)
+
+        client = Client()
+
+        client.force_login( api_request_permissions['user']['add'] )
+
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+        url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        response = client.post(
+            path = url,
+            data = kwargs_create,
+            content_type = 'application/json'
+        )
+
+        assert response.status_code == 201, response.content\
+

--- a/app/core/tests/functional/additional_ticketcommentactionfieldedit_permissions_api.py
+++ b/app/core/tests/functional/additional_ticketcommentactionfieldedit_permissions_api.py
@@ -1,0 +1,119 @@
+import pytest
+
+from django.test import Client
+
+
+
+class AdditionalTestCases:
+
+
+
+    @pytest.mark.xfail( reason = 'User requires import permission for add action comment' )
+    def test_api_add_exception(self, mocker, model_instance,
+        parameterized, param_key_exceptions, param_value,
+        param_exception, param_http_status,
+        api_request_permissions, model_kwargs, kwargs_api_create, model
+    ):
+
+        try:
+
+            client = Client()
+
+            client.force_login( api_request_permissions['user']['add'] )
+
+
+            kwargs = model_kwargs()
+            kwargs.update({
+                'organization': api_request_permissions['tenancy']['user']
+            })
+
+            the_model = model_instance( kwargs_create = kwargs )
+
+            url = the_model.get_url( many = True )
+
+            kwargs_create = kwargs_api_create.copy()
+            kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+            kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+            mocker.patch(
+                "access.managers.tenancy.TenancyManager.create",
+                side_effect = param_exception("an integrity error occured....")
+            )
+
+
+            response = client.post(
+                path = url,
+                data = kwargs_create,
+                content_type = 'application/json'
+            )
+
+
+            assert response.status_code == param_http_status, response.content
+
+        except AssertionError as ex:
+            pytest.xfail(
+                reason = (
+                    'User requires import permission for add action comment, '
+                    f'failure=[{ex}]'
+                )
+            )
+
+
+
+    @pytest.mark.skip( reason = 'ToDo: Write test case' )
+    def test_api_add_exception_import_user(self, mocker, model_instance,
+        parameterized, param_key_exceptions, param_value,
+        param_exception, param_http_status,
+        api_request_permissions, model_kwargs, kwargs_api_create, model
+    ):
+        """ API action capture exception
+
+        Ensure that during a `Create` operation that the exception is captured
+        and that the correct http status code is returned
+        """
+        pass
+
+
+
+    @pytest.mark.xfail( reason = 'Only import user can add an action comment' )
+    def test_permission_add(self, model_instance, api_request_permissions,
+        model_kwargs, kwargs_api_create,
+    ):
+
+        client = Client()
+
+        client.force_login( api_request_permissions['user']['add'] )
+
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+        url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        response = client.post(
+            path = url,
+            data = kwargs_create,
+            content_type = 'application/json'
+        )
+
+        assert response.status_code == 201, response.content\
+
+
+    @pytest.mark.skip( reason = 'ToDo: Write test case' )
+    def test_permission_add_import_user(self, model_instance, api_request_permissions,
+        model_kwargs, kwargs_api_create,
+    ):
+        """ Check correct permission for add 
+
+        Attempt to add as user with "import" permission
+        """
+        pass

--- a/app/core/tests/functional/additional_ticketcommentactionfieldedit_permissions_api.py
+++ b/app/core/tests/functional/additional_ticketcommentactionfieldedit_permissions_api.py
@@ -7,7 +7,6 @@ from django.test import Client
 class AdditionalTestCases:
 
 
-
     @pytest.mark.xfail( reason = 'User requires import permission for add action comment' )
     def test_api_add_exception(self, mocker, model_instance,
         parameterized, param_key_exceptions, param_value,
@@ -60,18 +59,61 @@ class AdditionalTestCases:
 
 
 
-    @pytest.mark.skip( reason = 'ToDo: Write test case' )
     def test_api_add_exception_import_user(self, mocker, model_instance,
         parameterized, param_key_exceptions, param_value,
         param_exception, param_http_status,
-        api_request_permissions, model_kwargs, kwargs_api_create, model
+        api_request_permissions, model_kwargs, kwargs_api_create, model,
+        model_contenttype
     ):
         """ API action capture exception
 
         Ensure that during a `Create` operation that the exception is captured
         and that the correct http status code is returned
         """
-        pass
+
+        user_role = api_request_permissions['user']['add'].groups.all(
+        )[0].roles.all()[0]
+
+        import_permission = model_contenttype.objects.get_for_model(
+            model
+        ).permission_set.get(
+            codename = f"import_{model._meta.model_name}"
+        )
+
+        user_role.permissions.add(import_permission)
+
+
+        client = Client()
+
+        client.force_login( api_request_permissions['user']['add'] )
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+        url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+        mocker.patch(
+            "access.managers.tenancy.TenancyManager.create",
+            side_effect = param_exception("an integrity error occured....")
+        )
+
+
+        response = client.post(
+            path = url,
+            data = kwargs_create,
+            content_type = 'application/json'
+        )
+
+
+        assert response.status_code == param_http_status, response.content
 
 
 
@@ -108,12 +150,50 @@ class AdditionalTestCases:
         assert response.status_code == 201, response.content\
 
 
-    @pytest.mark.skip( reason = 'ToDo: Write test case' )
+
     def test_permission_add_import_user(self, model_instance, api_request_permissions,
-        model_kwargs, kwargs_api_create,
+        model_kwargs, kwargs_api_create, model, model_contenttype
     ):
         """ Check correct permission for add 
 
         Attempt to add as user with "import" permission
         """
-        pass
+
+        user_role = api_request_permissions['user']['add'].groups.all(
+        )[0].roles.all()[0]
+
+        import_permission = model_contenttype.objects.get_for_model(
+            model
+        ).permission_set.get(
+            codename = f"import_{model._meta.model_name}"
+        )
+
+        user_role.permissions.add(import_permission)
+
+        client = Client()
+
+        client.force_login( api_request_permissions['user']['add'] )
+
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+        url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        response = client.post(
+            path = url,
+            data = kwargs_create,
+            content_type = 'application/json'
+        )
+
+        assert response.status_code == 201, response.content\
+

--- a/app/core/tests/functional/additional_ticketcommentactionmodellink_permissions_api.py
+++ b/app/core/tests/functional/additional_ticketcommentactionmodellink_permissions_api.py
@@ -1,0 +1,119 @@
+import pytest
+
+from django.test import Client
+
+
+
+class AdditionalTestCases:
+
+
+
+    @pytest.mark.xfail( reason = 'User requires import permission for add action comment' )
+    def test_api_add_exception(self, mocker, model_instance,
+        parameterized, param_key_exceptions, param_value,
+        param_exception, param_http_status,
+        api_request_permissions, model_kwargs, kwargs_api_create, model
+    ):
+
+        try:
+
+            client = Client()
+
+            client.force_login( api_request_permissions['user']['add'] )
+
+
+            kwargs = model_kwargs()
+            kwargs.update({
+                'organization': api_request_permissions['tenancy']['user']
+            })
+
+            the_model = model_instance( kwargs_create = kwargs )
+
+            url = the_model.get_url( many = True )
+
+            kwargs_create = kwargs_api_create.copy()
+            kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+            kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+            mocker.patch(
+                "access.managers.tenancy.TenancyManager.create",
+                side_effect = param_exception("an integrity error occured....")
+            )
+
+
+            response = client.post(
+                path = url,
+                data = kwargs_create,
+                content_type = 'application/json'
+            )
+
+
+            assert response.status_code == param_http_status, response.content
+
+        except AssertionError as ex:
+            pytest.xfail(
+                reason = (
+                    'User requires import permission for add action comment, '
+                    f'failure=[{ex}]'
+                )
+            )
+
+
+
+    @pytest.mark.skip( reason = 'ToDo: Write test case' )
+    def test_api_add_exception_import_user(self, mocker, model_instance,
+        parameterized, param_key_exceptions, param_value,
+        param_exception, param_http_status,
+        api_request_permissions, model_kwargs, kwargs_api_create, model
+    ):
+        """ API action capture exception
+
+        Ensure that during a `Create` operation that the exception is captured
+        and that the correct http status code is returned
+        """
+        pass
+
+
+
+    @pytest.mark.xfail( reason = 'Only import user can add an action comment' )
+    def test_permission_add(self, model_instance, api_request_permissions,
+        model_kwargs, kwargs_api_create,
+    ):
+
+        client = Client()
+
+        client.force_login( api_request_permissions['user']['add'] )
+
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+        url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        response = client.post(
+            path = url,
+            data = kwargs_create,
+            content_type = 'application/json'
+        )
+
+        assert response.status_code == 201, response.content\
+
+
+    @pytest.mark.skip( reason = 'ToDo: Write test case' )
+    def test_permission_add_import_user(self, model_instance, api_request_permissions,
+        model_kwargs, kwargs_api_create,
+    ):
+        """ Check correct permission for add 
+
+        Attempt to add as user with "import" permission
+        """
+        pass

--- a/app/core/tests/functional/additional_ticketcommentactionmodellink_permissions_api.py
+++ b/app/core/tests/functional/additional_ticketcommentactionmodellink_permissions_api.py
@@ -7,7 +7,6 @@ from django.test import Client
 class AdditionalTestCases:
 
 
-
     @pytest.mark.xfail( reason = 'User requires import permission for add action comment' )
     def test_api_add_exception(self, mocker, model_instance,
         parameterized, param_key_exceptions, param_value,
@@ -60,18 +59,61 @@ class AdditionalTestCases:
 
 
 
-    @pytest.mark.skip( reason = 'ToDo: Write test case' )
     def test_api_add_exception_import_user(self, mocker, model_instance,
         parameterized, param_key_exceptions, param_value,
         param_exception, param_http_status,
-        api_request_permissions, model_kwargs, kwargs_api_create, model
+        api_request_permissions, model_kwargs, kwargs_api_create, model,
+        model_contenttype
     ):
         """ API action capture exception
 
         Ensure that during a `Create` operation that the exception is captured
         and that the correct http status code is returned
         """
-        pass
+
+        user_role = api_request_permissions['user']['add'].groups.all(
+        )[0].roles.all()[0]
+
+        import_permission = model_contenttype.objects.get_for_model(
+            model
+        ).permission_set.get(
+            codename = f"import_{model._meta.model_name}"
+        )
+
+        user_role.permissions.add(import_permission)
+
+
+        client = Client()
+
+        client.force_login( api_request_permissions['user']['add'] )
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+        url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+        mocker.patch(
+            "access.managers.tenancy.TenancyManager.create",
+            side_effect = param_exception("an integrity error occured....")
+        )
+
+
+        response = client.post(
+            path = url,
+            data = kwargs_create,
+            content_type = 'application/json'
+        )
+
+
+        assert response.status_code == param_http_status, response.content
 
 
 
@@ -108,12 +150,50 @@ class AdditionalTestCases:
         assert response.status_code == 201, response.content\
 
 
-    @pytest.mark.skip( reason = 'ToDo: Write test case' )
+
     def test_permission_add_import_user(self, model_instance, api_request_permissions,
-        model_kwargs, kwargs_api_create,
+        model_kwargs, kwargs_api_create, model, model_contenttype
     ):
         """ Check correct permission for add 
 
         Attempt to add as user with "import" permission
         """
-        pass
+
+        user_role = api_request_permissions['user']['add'].groups.all(
+        )[0].roles.all()[0]
+
+        import_permission = model_contenttype.objects.get_for_model(
+            model
+        ).permission_set.get(
+            codename = f"import_{model._meta.model_name}"
+        )
+
+        user_role.permissions.add(import_permission)
+
+        client = Client()
+
+        client.force_login( api_request_permissions['user']['add'] )
+
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+        url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        response = client.post(
+            path = url,
+            data = kwargs_create,
+            content_type = 'application/json'
+        )
+
+        assert response.status_code == 201, response.content\
+

--- a/app/core/tests/functional/additional_ticketcommentactionticketdependency_permissions_api.py
+++ b/app/core/tests/functional/additional_ticketcommentactionticketdependency_permissions_api.py
@@ -1,0 +1,119 @@
+import pytest
+
+from django.test import Client
+
+
+
+class AdditionalTestCases:
+
+
+
+    @pytest.mark.xfail( reason = 'User requires import permission for add action comment' )
+    def test_api_add_exception(self, mocker, model_instance,
+        parameterized, param_key_exceptions, param_value,
+        param_exception, param_http_status,
+        api_request_permissions, model_kwargs, kwargs_api_create, model
+    ):
+
+        try:
+
+            client = Client()
+
+            client.force_login( api_request_permissions['user']['add'] )
+
+
+            kwargs = model_kwargs()
+            kwargs.update({
+                'organization': api_request_permissions['tenancy']['user']
+            })
+
+            the_model = model_instance( kwargs_create = kwargs )
+
+            url = the_model.get_url( many = True )
+
+            kwargs_create = kwargs_api_create.copy()
+            kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+            kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+            mocker.patch(
+                "access.managers.tenancy.TenancyManager.create",
+                side_effect = param_exception("an integrity error occured....")
+            )
+
+
+            response = client.post(
+                path = url,
+                data = kwargs_create,
+                content_type = 'application/json'
+            )
+
+
+            assert response.status_code == param_http_status, response.content
+
+        except AssertionError as ex:
+            pytest.xfail(
+                reason = (
+                    'User requires import permission for add action comment, '
+                    f'failure=[{ex}]'
+                )
+            )
+
+
+
+    @pytest.mark.skip( reason = 'ToDo: Write test case' )
+    def test_api_add_exception_import_user(self, mocker, model_instance,
+        parameterized, param_key_exceptions, param_value,
+        param_exception, param_http_status,
+        api_request_permissions, model_kwargs, kwargs_api_create, model
+    ):
+        """ API action capture exception
+
+        Ensure that during a `Create` operation that the exception is captured
+        and that the correct http status code is returned
+        """
+        pass
+
+
+
+    @pytest.mark.xfail( reason = 'Only import user can add an action comment' )
+    def test_permission_add(self, model_instance, api_request_permissions,
+        model_kwargs, kwargs_api_create,
+    ):
+
+        client = Client()
+
+        client.force_login( api_request_permissions['user']['add'] )
+
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+        url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        response = client.post(
+            path = url,
+            data = kwargs_create,
+            content_type = 'application/json'
+        )
+
+        assert response.status_code == 201, response.content\
+
+
+    @pytest.mark.skip( reason = 'ToDo: Write test case' )
+    def test_permission_add_import_user(self, model_instance, api_request_permissions,
+        model_kwargs, kwargs_api_create,
+    ):
+        """ Check correct permission for add 
+
+        Attempt to add as user with "import" permission
+        """
+        pass

--- a/app/core/tests/functional/additional_ticketcommentactionticketdependency_permissions_api.py
+++ b/app/core/tests/functional/additional_ticketcommentactionticketdependency_permissions_api.py
@@ -7,7 +7,6 @@ from django.test import Client
 class AdditionalTestCases:
 
 
-
     @pytest.mark.xfail( reason = 'User requires import permission for add action comment' )
     def test_api_add_exception(self, mocker, model_instance,
         parameterized, param_key_exceptions, param_value,
@@ -60,18 +59,61 @@ class AdditionalTestCases:
 
 
 
-    @pytest.mark.skip( reason = 'ToDo: Write test case' )
     def test_api_add_exception_import_user(self, mocker, model_instance,
         parameterized, param_key_exceptions, param_value,
         param_exception, param_http_status,
-        api_request_permissions, model_kwargs, kwargs_api_create, model
+        api_request_permissions, model_kwargs, kwargs_api_create, model,
+        model_contenttype
     ):
         """ API action capture exception
 
         Ensure that during a `Create` operation that the exception is captured
         and that the correct http status code is returned
         """
-        pass
+
+        user_role = api_request_permissions['user']['add'].groups.all(
+        )[0].roles.all()[0]
+
+        import_permission = model_contenttype.objects.get_for_model(
+            model
+        ).permission_set.get(
+            codename = f"import_{model._meta.model_name}"
+        )
+
+        user_role.permissions.add(import_permission)
+
+
+        client = Client()
+
+        client.force_login( api_request_permissions['user']['add'] )
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+        url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+        mocker.patch(
+            "access.managers.tenancy.TenancyManager.create",
+            side_effect = param_exception("an integrity error occured....")
+        )
+
+
+        response = client.post(
+            path = url,
+            data = kwargs_create,
+            content_type = 'application/json'
+        )
+
+
+        assert response.status_code == param_http_status, response.content
 
 
 
@@ -108,12 +150,50 @@ class AdditionalTestCases:
         assert response.status_code == 201, response.content\
 
 
-    @pytest.mark.skip( reason = 'ToDo: Write test case' )
+
     def test_permission_add_import_user(self, model_instance, api_request_permissions,
-        model_kwargs, kwargs_api_create,
+        model_kwargs, kwargs_api_create, model, model_contenttype
     ):
         """ Check correct permission for add 
 
         Attempt to add as user with "import" permission
         """
-        pass
+
+        user_role = api_request_permissions['user']['add'].groups.all(
+        )[0].roles.all()[0]
+
+        import_permission = model_contenttype.objects.get_for_model(
+            model
+        ).permission_set.get(
+            codename = f"import_{model._meta.model_name}"
+        )
+
+        user_role.permissions.add(import_permission)
+
+        client = Client()
+
+        client.force_login( api_request_permissions['user']['add'] )
+
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+        url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['created_by'] = api_request_permissions['user']['add'].id
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        response = client.post(
+            path = url,
+            data = kwargs_create,
+            content_type = 'application/json'
+        )
+
+        assert response.status_code == 201, response.content\
+

--- a/app/core/tests/functional/ticket_dependency/test_functional_ticket_dependency_model.py
+++ b/app/core/tests/functional/ticket_dependency/test_functional_ticket_dependency_model.py
@@ -26,4 +26,38 @@ class TicketDependencyModelInheritedCases(
 class TicketDependencyModelPyTest(
     TicketDependencyModelTestCases,
 ):
-    pass
+
+
+
+    def test_model_delete_removes_inverse_dependency(self, model, created_model):
+        """Model Delete Check
+
+        When a ticket dependency is deleted, it must also remove the ticket
+        dependency in the opposite direction.
+        """
+
+        db_model = model.objects.get( id = created_model.id )
+
+        ticket = db_model.ticket
+
+        dependent_ticket = db_model.dependent_ticket
+
+
+        model.objects.create(
+            ticket = dependent_ticket,
+            how_related = db_model.how_related,
+            dependent_ticket = ticket,
+            organization = dependent_ticket.organization,
+            user = db_model.user
+        )
+
+        db_model.delete()
+
+        db_check = model.objects.filter(
+            ticket = dependent_ticket,
+            dependent_ticket = ticket,
+        )
+
+
+        assert len(db_check) == 0
+

--- a/app/core/tests/integration/additional_ticketcommentaction_model_endpoints.py
+++ b/app/core/tests/integration/additional_ticketcommentaction_model_endpoints.py
@@ -1,0 +1,99 @@
+import pytest
+
+from centurion.tests.integration.test_integration_common import (
+    IntegrationCommon
+)
+
+
+
+class AdditionalTestCases:
+
+
+    @pytest.mark.xfail( reason = 'Only an import user can create this model.' )
+    def test_backend_crud_create(self,
+        auto_login_client, api_request_permissions, kwargs_api_create,
+        model_instance, model_kwargs, model_contenttype
+    ):
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+
+        model_relative_url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        url = f"{IntegrationCommon.API_URL}{model_relative_url}"
+
+        response = auto_login_client.request(
+            auth = True,
+            re_login = api_request_permissions['user']['add'],
+            json = kwargs_create,
+            headers = {
+                'Content-Type': 'application/json'
+            },
+            method = "POST",
+            url = url,
+        )
+
+
+        assert response.status_code == 201, response.content
+
+
+
+    def test_backend_crud_create_import_permission(self,
+        auto_login_client, api_request_permissions, kwargs_api_create,
+        model_instance, model_kwargs, model_contenttype
+    ):
+        """ Test Create endpoint
+
+        An import user must be able to create this model.
+        """
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+
+        user_role = api_request_permissions['user']['add'].groups.all(
+        )[0].roles.all()[0]
+
+        import_permission = model_contenttype.objects.get_for_model(
+            the_model.__class__
+        ).permission_set.get(
+            codename = f"import_{the_model.__class__._meta.model_name}"
+        )
+
+        user_role.permissions.add(import_permission)
+
+
+        model_relative_url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        url = f"{IntegrationCommon.API_URL}{model_relative_url}"
+
+        response = auto_login_client.request(
+            auth = True,
+            re_login = api_request_permissions['user']['add'],
+            json = kwargs_create,
+            headers = {
+                'Content-Type': 'application/json'
+            },
+            method = "POST",
+            url = url,
+        )
+
+
+        assert response.status_code == 201, response.content

--- a/app/core/tests/integration/additional_ticketcommentactionfieldedit_model_endpoints.py
+++ b/app/core/tests/integration/additional_ticketcommentactionfieldedit_model_endpoints.py
@@ -1,0 +1,99 @@
+import pytest
+
+from centurion.tests.integration.test_integration_common import (
+    IntegrationCommon
+)
+
+
+
+class AdditionalTestCases:
+
+
+    @pytest.mark.xfail( reason = 'Only an import user can create this model.' )
+    def test_backend_crud_create(self,
+        auto_login_client, api_request_permissions, kwargs_api_create,
+        model_instance, model_kwargs, model_contenttype
+    ):
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+
+        model_relative_url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        url = f"{IntegrationCommon.API_URL}{model_relative_url}"
+
+        response = auto_login_client.request(
+            auth = True,
+            re_login = api_request_permissions['user']['add'],
+            json = kwargs_create,
+            headers = {
+                'Content-Type': 'application/json'
+            },
+            method = "POST",
+            url = url,
+        )
+
+
+        assert response.status_code == 201, response.content
+
+
+
+    def test_backend_crud_create_import_permission(self,
+        auto_login_client, api_request_permissions, kwargs_api_create,
+        model_instance, model_kwargs, model_contenttype
+    ):
+        """ Test Create endpoint
+
+        An import user must be able to create this model.
+        """
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+
+        user_role = api_request_permissions['user']['add'].groups.all(
+        )[0].roles.all()[0]
+
+        import_permission = model_contenttype.objects.get_for_model(
+            the_model.__class__
+        ).permission_set.get(
+            codename = f"import_{the_model.__class__._meta.model_name}"
+        )
+
+        user_role.permissions.add(import_permission)
+
+
+        model_relative_url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        url = f"{IntegrationCommon.API_URL}{model_relative_url}"
+
+        response = auto_login_client.request(
+            auth = True,
+            re_login = api_request_permissions['user']['add'],
+            json = kwargs_create,
+            headers = {
+                'Content-Type': 'application/json'
+            },
+            method = "POST",
+            url = url,
+        )
+
+
+        assert response.status_code == 201, response.content

--- a/app/core/tests/integration/additional_ticketcommentactionmodellink_model_endpoints.py
+++ b/app/core/tests/integration/additional_ticketcommentactionmodellink_model_endpoints.py
@@ -1,0 +1,99 @@
+import pytest
+
+from centurion.tests.integration.test_integration_common import (
+    IntegrationCommon
+)
+
+
+
+class AdditionalTestCases:
+
+
+    @pytest.mark.xfail( reason = 'Only an import user can create this model.' )
+    def test_backend_crud_create(self,
+        auto_login_client, api_request_permissions, kwargs_api_create,
+        model_instance, model_kwargs, model_contenttype
+    ):
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+
+        model_relative_url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        url = f"{IntegrationCommon.API_URL}{model_relative_url}"
+
+        response = auto_login_client.request(
+            auth = True,
+            re_login = api_request_permissions['user']['add'],
+            json = kwargs_create,
+            headers = {
+                'Content-Type': 'application/json'
+            },
+            method = "POST",
+            url = url,
+        )
+
+
+        assert response.status_code == 201, response.content
+
+
+
+    def test_backend_crud_create_import_permission(self,
+        auto_login_client, api_request_permissions, kwargs_api_create,
+        model_instance, model_kwargs, model_contenttype
+    ):
+        """ Test Create endpoint
+
+        An import user must be able to create this model.
+        """
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+
+        user_role = api_request_permissions['user']['add'].groups.all(
+        )[0].roles.all()[0]
+
+        import_permission = model_contenttype.objects.get_for_model(
+            the_model.__class__
+        ).permission_set.get(
+            codename = f"import_{the_model.__class__._meta.model_name}"
+        )
+
+        user_role.permissions.add(import_permission)
+
+
+        model_relative_url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        url = f"{IntegrationCommon.API_URL}{model_relative_url}"
+
+        response = auto_login_client.request(
+            auth = True,
+            re_login = api_request_permissions['user']['add'],
+            json = kwargs_create,
+            headers = {
+                'Content-Type': 'application/json'
+            },
+            method = "POST",
+            url = url,
+        )
+
+
+        assert response.status_code == 201, response.content

--- a/app/core/tests/integration/additional_ticketcommentactionticketdependency_model_endpoints.py
+++ b/app/core/tests/integration/additional_ticketcommentactionticketdependency_model_endpoints.py
@@ -1,0 +1,99 @@
+import pytest
+
+from centurion.tests.integration.test_integration_common import (
+    IntegrationCommon
+)
+
+
+
+class AdditionalTestCases:
+
+
+    @pytest.mark.xfail( reason = 'Only an import user can create this model.' )
+    def test_backend_crud_create(self,
+        auto_login_client, api_request_permissions, kwargs_api_create,
+        model_instance, model_kwargs, model_contenttype
+    ):
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+
+        model_relative_url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        url = f"{IntegrationCommon.API_URL}{model_relative_url}"
+
+        response = auto_login_client.request(
+            auth = True,
+            re_login = api_request_permissions['user']['add'],
+            json = kwargs_create,
+            headers = {
+                'Content-Type': 'application/json'
+            },
+            method = "POST",
+            url = url,
+        )
+
+
+        assert response.status_code == 201, response.content
+
+
+
+    def test_backend_crud_create_import_permission(self,
+        auto_login_client, api_request_permissions, kwargs_api_create,
+        model_instance, model_kwargs, model_contenttype
+    ):
+        """ Test Create endpoint
+
+        An import user must be able to create this model.
+        """
+
+        kwargs = model_kwargs()
+        kwargs.update({
+            'organization': api_request_permissions['tenancy']['user']
+        })
+
+        the_model = model_instance( kwargs_create = kwargs )
+
+
+        user_role = api_request_permissions['user']['add'].groups.all(
+        )[0].roles.all()[0]
+
+        import_permission = model_contenttype.objects.get_for_model(
+            the_model.__class__
+        ).permission_set.get(
+            codename = f"import_{the_model.__class__._meta.model_name}"
+        )
+
+        user_role.permissions.add(import_permission)
+
+
+        model_relative_url = the_model.get_url( many = True )
+
+        kwargs_create = kwargs_api_create.copy()
+        kwargs_create['organization'] = api_request_permissions['tenancy']['user'].id
+
+
+        url = f"{IntegrationCommon.API_URL}{model_relative_url}"
+
+        response = auto_login_client.request(
+            auth = True,
+            re_login = api_request_permissions['user']['add'],
+            json = kwargs_create,
+            headers = {
+                'Content-Type': 'application/json'
+            },
+            method = "POST",
+            url = url,
+        )
+
+
+        assert response.status_code == 201, response.content

--- a/app/core/viewsets/ticket_comment.py
+++ b/app/core/viewsets/ticket_comment.py
@@ -345,17 +345,28 @@ class ViewSet(
                     ).get_related_model()
 
 
-                if ticket:
+                if(
+                    self.model()._base_model._meta.model_name == 'ticketcommentaction'
+                    or self.model._meta.model_name == 'ticketcommentaction'
+                    ):
 
-                    triage_permission: str = f'{ticket._meta.app_label}.triage_{ticket._meta.model_name}'
+                    action_comment_import_permission: str = f'{self.model._meta.app_label}.import_{self.model._meta.model_name}'
+
+                    self._perms_map: dict[str, list[str]] = {
+                        'POST': [ action_comment_import_permission ],
+                    }
+
+                elif ticket:
+
+                    ticket_triage_permission: str = f'{ticket._meta.app_label}.triage_{ticket._meta.model_name}'
 
                     if self.model._meta.model_name == 'ticketcommenttask':
 
                         self._perms_map: dict[str, list[str]] = {
-                            'POST': [ triage_permission ],
-                            'PUT': [ triage_permission ],
-                            'PATCH': [ triage_permission ],
-                            'DELETE': [ triage_permission ],
+                            'POST': [ ticket_triage_permission ],
+                            'PUT': [ ticket_triage_permission ],
+                            'PATCH': [ ticket_triage_permission ],
+                            'DELETE': [ ticket_triage_permission ],
                         }
 
             except Exception:

--- a/app/itam/viewsets/device_operating_system.py
+++ b/app/itam/viewsets/device_operating_system.py
@@ -128,20 +128,6 @@ class ViewSet( ModelViewSet ):
     view_description = 'Device Operating System'
 
 
-    @property
-    def allowed_methods(self):
-
-        allowed_methods = super().allowed_methods
-
-        if self.kwargs.get('operating_system_id', None):
-
-            if 'PATCH' in allowed_methods: allowed_methods.remove('PATCH')
-            if 'POST' in allowed_methods: allowed_methods.remove('POST')
-            if 'PUT' in allowed_methods: allowed_methods.remove('PUT')
-
-        return allowed_methods
-
-
     def get_queryset(self):
 
         if self.queryset is not None:

--- a/docs/projects/centurion_erp/development/permissions.md
+++ b/docs/projects/centurion_erp/development/permissions.md
@@ -33,6 +33,8 @@ All Permission Classes must meet the following requirements:
 
 - No Merge request that contains a permissions class will be merged unless the permissions class is [tested](./testing.md). This includes **all** branches.
 
+- Function `api.permissions.common.permission_allowed_finaliser` must be called for a user granted permission. This function has been designed so that it can be used as part of the return call for the `has_permission` function of the permission class.
+
 
 ## Centurion Model Permissions
 

--- a/docs/projects/centurion_erp/index.md
+++ b/docs/projects/centurion_erp/index.md
@@ -116,7 +116,7 @@ Feature table uses the following keys:
 | | Test Management | :x: |  |
 | | Release Management | :x: |  |
 | | [Repository Management](./user/devops/git_repository.md) | :recycle: | _[see #115](https://github.com/nofusscomputing/centurion_erp/issues/115)_ |
-| | Requirements Management | :x: |  |
+| | Requirements Management | :x: | _[see #1175](https://github.com/nofusscomputing/centurion_erp/issues/1175)_ |
 | | Version Control / Source Code Management | :x: |  |
 | | Public Repository Management | :x: | _[see #998](https://github.com/nofusscomputing/centurion_erp/issues/998)_ |
 | Facilities Management ||| _[see #574](https://github.com/nofusscomputing/centurion_erp/issues/574)_ |

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,13 +20,13 @@ celery==5.4.0
     # via
     #   -r tools/requirements.in
     #   django-celery-results
-certifi==2026.5.20
+certifi==2026.6.17
     # via requests
 cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via
     #   celery
     #   click-didyoumean
@@ -38,7 +38,7 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-cryptography==48.0.0
+cryptography==49.0.0
     # via
     #   pyjwt
     #   social-auth-core
@@ -76,11 +76,11 @@ djangorestframework-jsonapi==7.1.0
     # via -r tools/requirements.in
 drf-spectacular[sidecar]==0.29.0
     # via -r tools/requirements.in
-drf-spectacular-sidecar==2026.5.1
+drf-spectacular-sidecar==2026.6.1
     # via drf-spectacular
-greenlet==3.5.1
+greenlet==3.5.2
     # via sqlalchemy
-idna==3.15
+idna==3.18
     # via requests
 inflection==0.5.1
     # via
@@ -116,7 +116,7 @@ pycparser==3.0
     # via cffi
 pygments==2.20.0
     # via -r tools/requirements.in
-pyjwt[crypto]==2.12.1
+pyjwt[crypto]==2.13.0
     # via social-auth-core
 python-dateutil==2.9.0.post0
     # via celery
@@ -140,6 +140,7 @@ requests-oauthlib==2.0.0
     # via social-auth-core
 rpds-py==0.30.0
     # via
+    #   -r tools/requirements.in
     #   jsonschema
     #   referencing
 six==1.17.0
@@ -172,5 +173,5 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.7.0
+wcwidth==0.8.1
     # via prompt-toolkit

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -40,7 +40,7 @@ celery==5.4.0
     #   -r requirements.txt
     #   -r requirements_production.txt
     #   django-celery-results
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
@@ -58,7 +58,7 @@ charset-normalizer==3.4.7
     #   requests
 check-wheel-contents==0.6.3
     # via -r tools/requirements_dev.in
-click==8.4.0
+click==8.4.1
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
@@ -91,7 +91,7 @@ coverage[toml]==7.8.0
     # via
     #   -r tools/requirements_dev.in
     #   pytest-cov
-cryptography==48.0.0
+cryptography==49.0.0
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
@@ -156,17 +156,17 @@ drf-spectacular[sidecar]==0.29.0
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
-drf-spectacular-sidecar==2026.5.1
+drf-spectacular-sidecar==2026.6.1
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
     #   drf-spectacular
-greenlet==3.5.1
+greenlet==3.5.2
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
     #   sqlalchemy
-idna==3.15
+idna==3.18
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
@@ -239,7 +239,7 @@ packaging==26.2
     #   wheel
 pip-tools==7.5.3
     # via -r tools/requirements_dev.in
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via pylint
 pluggy==1.6.0
     # via pytest
@@ -269,7 +269,7 @@ pygments==2.20.0
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
-pyjwt[crypto]==2.12.1
+pyjwt[crypto]==2.13.0
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
@@ -411,7 +411,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.7.0
+wcwidth==0.8.1
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -31,7 +31,7 @@ celery==5.4.0
     #   -r requirements.txt
     #   -r requirements_production.txt
     #   django-celery-results
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
@@ -46,7 +46,7 @@ charset-normalizer==3.4.7
     #   -r requirements.txt
     #   -r requirements_production.txt
     #   requests
-click==8.4.0
+click==8.4.1
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
@@ -69,7 +69,7 @@ click-repl==0.3.0
     #   -r requirements.txt
     #   -r requirements_production.txt
     #   celery
-cryptography==48.0.0
+cryptography==49.0.0
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
@@ -127,17 +127,17 @@ drf-spectacular[sidecar]==0.29.0
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
-drf-spectacular-sidecar==2026.5.1
+drf-spectacular-sidecar==2026.6.1
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
     #   drf-spectacular
-greenlet==3.5.1
+greenlet==3.5.2
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
     #   sqlalchemy
-idna==3.15
+idna==3.18
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
@@ -212,7 +212,7 @@ pygments==2.20.0
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
-pyjwt[crypto]==2.12.1
+pyjwt[crypto]==2.13.0
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt
@@ -320,7 +320,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.7.0
+wcwidth==0.8.1
     # via
     #   -r requirements.txt
     #   -r requirements_production.txt

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -26,7 +26,7 @@ celery==5.4.0
     # via
     #   -r requirements.txt
     #   django-celery-results
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements.txt
     #   requests
@@ -38,7 +38,7 @@ charset-normalizer==3.4.7
     # via
     #   -r requirements.txt
     #   requests
-click==8.4.0
+click==8.4.1
     # via
     #   -r requirements.txt
     #   celery
@@ -57,7 +57,7 @@ click-repl==0.3.0
     # via
     #   -r requirements.txt
     #   celery
-cryptography==48.0.0
+cryptography==49.0.0
     # via
     #   -r requirements.txt
     #   pyjwt
@@ -97,15 +97,15 @@ djangorestframework-jsonapi==7.1.0
     # via -r requirements.txt
 drf-spectacular[sidecar]==0.29.0
     # via -r requirements.txt
-drf-spectacular-sidecar==2026.5.1
+drf-spectacular-sidecar==2026.6.1
     # via
     #   -r requirements.txt
     #   drf-spectacular
-greenlet==3.5.1
+greenlet==3.5.2
     # via
     #   -r requirements.txt
     #   sqlalchemy
-idna==3.15
+idna==3.18
     # via
     #   -r requirements.txt
     #   requests
@@ -165,7 +165,7 @@ pycparser==3.0
     #   cffi
 pygments==2.20.0
     # via -r requirements.txt
-pyjwt[crypto]==2.12.1
+pyjwt[crypto]==2.13.0
     # via
     #   -r requirements.txt
     #   social-auth-core
@@ -248,7 +248,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.7.0
+wcwidth==0.8.1
     # via
     #   -r requirements.txt
     #   prompt-toolkit

--- a/tools/requirements.in
+++ b/tools/requirements.in
@@ -56,3 +56,10 @@ tzdata==2025.1
 markdown-it-py[plugins]==3.0.0
 markdown-it-py[linkify]==3.0.0
 Pygments==2.20.0
+
+
+# ##################################################
+#  Freeze deps of deps to specified version
+# ##################################################
+
+rpds-py==0.30.0    # v2026.5.1 does not work with python 3.10


### PR DESCRIPTION
### :books: Summary
<!-- your summary here emojis ref: https://github.com/yodamad/gitlab-emoji -->



### :link: Links / References
<!-- 

    using a list as any links to other references or links as required. if relevant, describe the link/reference

    Include any issues or related merge requests. Note: dependent MR's also to be added to "Merge request dependencies"

-->

- Related: https://github.com/nofusscomputing/centurion_erp_ui/issues/117
- Related: #1159 
- Related: #1161 
- Related: #1165 



### :construction_worker: Tasks

 - [ ] Add your tasks here if required (delete)

<!-- dont remove tasks below strike through including the checkbox by enclosing in double tidle '~~' -->

 - [ ] **Feature Release ONLY** :red_square: [Squash migration files](https://docs.djangoproject.com/en/5.2/topics/migrations/#squashing-migrations) :red_square: 
    _Multiple migration files created as part of this release are to be sqauashed into a few files as possible so as to limit the number of migrations_ 

- [ ] :firecracker: Contains breaking-change Any Breaking change(s)?

    _Breaking Change must also be notated in the commit that introduces it and in [Conventional Commit Format](https://www.conventionalcommits.org/en/v1.0.0/)._

    - [ ] :notebook: Release notes updated

- [ ] :blue_book: Documentation written

    _All features to be documented within the correct section(s). Administration, Development and/or User_

- [ ] :checkered_flag: Milestone assigned

- [ ] :gear: :test_tube: [Functional Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

- [ ] :test_tube: [Unit Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

    _ensure test coverage delta is not less than zero_

- [ ] :page_facing_up: Roadmap updated
