### PR TITLE
docs(development): Reorganise the contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,186 +1,161 @@
 # Contribution Guide
 
 
-Development of this project has been setup to be done from VSCodium. The following additional requirements need to be met:
+Development of this project has been setup to be done from VSCodium. This guide
+covers the requirements, how to start a local development server, the available
+`make` targets, linting, testing and running the stack under Docker.
 
-- npm has been installed. _required for `markdown` linting_
-
-    `sudo apt install -y --no-install-recommends npm`
-
-- setup of other requirements can be done with `make prepare`
-
-- **ALL** Linting must pass for Merge to be conducted.
-
-    _`make lint`_
-
-## TL;DR
+Further development documentation relevant to the code itself is available at
+<https://nofusscomputing.com/projects/centurion_erp/development/>.
 
 
-from the root of the project to start a test server use:
+## Requirements
+
+
+The following additional requirements need to be met:
+
+- `npm` is installed. _required for `markdown` linting_
+
+    ``` bash
+
+    sudo apt install -y --no-install-recommends npm
+
+    ```
+
+- Setup of the remaining requirements is done with `make prepare-python`. This
+    initialises the git submodules and sets up the Python virtual environment.
+
+- **ALL** linting must pass for a merge to be conducted (`make lint`).
+
+
+## Quick Start
+
+
+From the root of the project, to start a test server use:
 
 ``` bash
 
-# activate python venv
+# Activate the python venv
 source /tmp/centurion_erp/bin/activate
 
-# enter app dir
+# Enter the app dir
 cd app
 
-# Start dev server can be viewed at http://127.0.0.1:8002
+# Start the dev server, viewable at http://127.0.0.1:8002
 python manage.py runserver 8002
 
 # Run any migrations, if required
 python manage.py migrate
 
-# Create a super suer if required
+# Create a super user, if required
 python manage.py createsuperuser
 
 ```
 
-## Makefile
-
-!!! tip "TL;DR"
-    Common make commands are `make prepare` then `make docs` and `make lint`
-
-Included within the root of the repository is a makefile that can be used during development to check/run different items as is required during development. The following make targets are available:
-
-- `prepare`
-
-    _prepare the repository. init's all git submodules and sets up a python virtual env and other make targets_
-
-- `docs`
-
-    _builds the docs and places them within a directory called build, which can be viewed within a web browser_
-
-- `lint`
-
-    _conducts all required linting_
-
-    - `docs-lint`
-
-        _lints the markdown documents within the docs directory for formatting errors that MKDocs may/will have an issue with._
-
-- `pip-file`
-
-    _Compiles pip files in `tools/` directory_
-
-- `pip`
-
-    _syncronises pip packages (Note: uses current python. i.e. if virtual env activated will sync packages within virtual env.)_
-
-- `clean`
-
-    _cleans up build artifacts and removes the python virtual environment_
-
-
-> this doc is yet to receive a re-write
-
-
-## Docker Container
-
-within the `deploy/` directory there is a docker compose file. running `docker compose up` from this directory will launch a full stack deployment locally containing Centurion API, User Interface, a worker and a RabbitMQ server. once launched you can navigate to `http://127.0.0.1/` to start browsing the site.
-
-You may need to run migrations if your not mounting your own DB. to do this run `docker exec -ti centurion-erp python manage.py migrate`
-
-## Page speed tests
-
-to run page speed tests (requires a working prometheus and grafa setup). use the following
-
+If you have made model changes, generate the migrations and regenerate the
+database test fixtures (migrations are disabled for tests, so the fixtures are
+what the test suite relies upon):
 
 ``` bash
 
-clear; \
-  K6_PROMETHEUS_RW_TREND_STATS="p(99),p(95),p(90),max,min" \
-  K6_PROMETHEUS_RW_SERVER_URL=http://<prometheus url>:9090/api/v1/write \
-  BASE_URL="http://127.0.0.1:8002" \
-  AUTH_TOKEN="< api token of superuser>" \
-  k6 run \
-    -o experimental-prometheus-rw \
-    --tag "commit=$(git rev-parse HEAD)" \
-    --tag "testid=<name of test for ref>" \
-    test/page_speed.js
+python manage.py makemigrations
+
+# Only required if not already setup
+make prepare-python
+
+# Generates the DB test fixtures
+# app/fixtures/fresh_db.json <- Dont commit this file as the only thing that should change is the date
+# app/fixtures/fresh_db.sql <- only commit this file if there are actual changes i.e. Tables are different or the django_migrations count has changed.
+make fixtures
 
 ```
 
-
-
-
-
-## Tips / Handy info
-
-- To obtain a list of models _(in in the same order as the file system)_ using the db shell `python3 manage.py dbshell` run the following sql command:
-
-    ``` sql
-
-    SELECT model FROM django_content_type ORDER BY app_label ASC, model ASC;
-
-    ```
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-# Old working docs
-
-
-## Dev Environment
-
-It's advised to setup a python virtual env for development. this can be done with the following commands.
+To update the code-highlight stylesheet run:
 
 ``` bash
 
-python3 -m venv venv
-
-source venv/bin/activate
-
-pip install -r requirements.txt
-
-```
-
-To setup the centurion erp test server run the following
-
-``` bash
-
-cd app
-
-python manage.py runserver 8002
-
-python3 manage.py migrate
-
-python3 manage.py createsuperuser
-
-# If model changes
-python3 manage.py makemigrations --noinput
-
-# To update code highlight run
 pygmentize -S default -f html -a .codehilite > project-static/code.css
 
 ```
 
-Updates to python modules will need to be captured with SCM. This can be done by running `pip freeze > requirements.txt` from the running virtual environment.
+
+## Makefile
 
 
+> [!TIP]
+> Common `make` commands are `make prepare-python` then `make docs` and
+> `make lint`.
 
-## Tests
+Included within the root of the repository is a makefile that can be used during
+development to check/run different items as required. The following make targets
+are available:
 
-!!! danger "Requirement"
-    All models **are** to have tests written for them, Including testing between dependent models. 
+- `prepare-python`
 
-See [Documentation](https://nofusscomputing.com/projects/django-template/development/testing/) for further information
+    _Initialises the git submodules and sets up the python virtual environment
+    and the other make targets._
+
+- `docs`
+
+    _Builds the docs and places them within a directory called `build`, which
+    can be viewed within a web browser._
+
+- `lint`
+
+    _Conducts all required linting._
+
+    - `docs-lint`
+
+        _Lints the markdown documents within the docs directory for formatting
+        errors that MkDocs may/will have an issue with._
+
+- `fixtures`
+
+    _Generates the database test fixtures (`app/fixtures/`)._
+
+- `pip-file`
+
+    _Compiles the pip files in the `tools/` directory._
+
+- `pip`
+
+    _Synchronises pip packages. Note: uses the current python, i.e. if a virtual
+    env is activated it will sync packages within the virtual env._
+
+- `clean`
+
+    _Cleans up build artifacts and removes the python virtual environment._
 
 
-## Docker Container
+## Linting
+
+
+All linting must pass before a merge can be conducted:
+
+``` bash
+
+make lint
+
+```
+
+
+## Testing
+
+
+> [!IMPORTANT]
+> **"Requirement"**
+>
+> All models **are** to have tests written for them, including testing between
+> dependent models.
+
+See the [testing documentation](https://nofusscomputing.com/projects/centurion_erp/development/testing/)
+for further information.
+
+
+## Docker
+
+
+To build and run a single Centurion image:
 
 ``` bash
 
@@ -192,3 +167,37 @@ docker run -d --rm -v ${PWD}/db.sqlite3:/app/db.sqlite3 -p 8002:8000 --name app 
 
 ```
 
+
+## Page speed tests
+
+
+To run page speed tests (requires a working prometheus and grafana setup) use
+the following:
+
+``` bash
+
+clear; \
+  K6_PROMETHEUS_RW_TREND_STATS="p(99),p(95),p(90),max,min" \
+  K6_PROMETHEUS_RW_SERVER_URL=http://<prometheus url>:9090/api/v1/write \
+  BASE_URL="http://127.0.0.1:8002" \
+  AUTH_TOKEN="<api token of superuser>" \
+  k6 run \
+    -o experimental-prometheus-rw \
+    --tag "commit=$(git rev-parse HEAD)" \
+    --tag "testid=<name of test for ref>" \
+    test/page_speed.js
+
+```
+
+
+## Tips / Handy info
+
+
+- To obtain a list of models _(in the same order as the file system)_ using the
+    db shell `python3 manage.py dbshell`, run the following SQL command:
+
+    ``` sql
+
+    SELECT model FROM django_content_type ORDER BY app_label ASC, model ASC;
+
+    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,8 +92,7 @@ are available:
 
 - `prepare-python`
 
-    _Initialises the git submodules and sets up the python virtual environment
-    and the other make targets._
+    _Sets up the python virtual environment._
 
 - `docs`
 
@@ -137,7 +136,9 @@ All linting must pass before a merge can be conducted:
 make lint
 
 ```
-
+> [!TIP]
+>
+> In your forked repo of Centurion ERP, if you activate github actions, every time you push a commit the CI lint job will run.
 
 ## Testing
 


### PR DESCRIPTION
### :books: Summary
<!-- your summary here emojis ref: https://github.com/yodamad/gitlab-emoji -->

Reorganise the root `CONTRIBUTING.md`, which was flagged as _"yet to receive a
re-write"_ and contained a duplicated, contradictory `# Old working docs`
section (two different venv setups and two Docker sections).

The guide is now structured into clear sections — Requirements, Quick Start,
Makefile, Linting, Testing, Docker, Page speed tests and Tips — with the unique
content from the old section (makemigrations, code-highlight generation, the
testing requirement and the single-image Docker build) folded into the relevant
places. Repository markdown conventions are applied (blank lines around headings,
no excess blank lines). **No commands were changed.**


### :link: Links / References
<!--
    using a list as any links to other references or links as required. if relevent, describe the link/reference
    Include any issues or related merge requests. Note: dependent MR's also to be added to "Merge request dependencies"
-->

N/A


### :construction_worker: Tasks

- [x] :large_blue_circle: Documentation written

    _Documentation-only change to the Development contribution guide._

- [ ] :orange_circle: Related issue(s) closed via [commit message](https://www.conventionalcommits.org/en/v1.0.0) footer

- [ ] :yellow_circle: Contains `breaking-change` Any Breaking change(s)? [commit message](https://www.conventionalcommits.org/en/v1.0.0)

    - [ ] :memo: Release notes updated

- [x] Milestone assigned

- [ ] :test_tube: [Unit Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/) — _N/A, docs only_

- [ ] :page_facing_up: Roadmap updated — _N/A_
