### PR TITLE
fix(access): Give the entity Base serializers unique schema component names

### DIFF
--- a/app/access/serializers/entity_company.py
+++ b/app/access/serializers/entity_company.py
@@ -10,6 +10,7 @@ from access.serializers.organization import TenantBaseSerializer
 
 
 
+@extend_schema_serializer(component_name = 'CompanyEntityBaseSerializer')
 class BaseSerializer(
     BaseBaseSerializer,
 ):

--- a/app/access/serializers/entity_contact.py
+++ b/app/access/serializers/entity_contact.py
@@ -10,6 +10,7 @@ from access.serializers.organization import TenantBaseSerializer
 
 
 
+@extend_schema_serializer(component_name = 'ContactEntityBaseSerializer')
 class BaseSerializer(
     BaseBaseSerializer,
 ):

--- a/app/access/serializers/entity_person.py
+++ b/app/access/serializers/entity_person.py
@@ -10,6 +10,7 @@ from access.serializers.organization import TenantBaseSerializer
 
 
 
+@extend_schema_serializer(component_name = 'PersonEntityBaseSerializer')
 class BaseSerializer(
     BaseBaseSerializer,
 ):


### PR DESCRIPTION
### :books: Summary

First slice of #361, scoped to the **Entity** serializer group as suggested by @jon-nfc.

The `BaseSerializer` classes in `entity_company`, `entity_person` and `entity_contact` had no explicit `component_name`, so drf-spectacular resolved them to the same `EntityBaseBase` component as `access.serializers.entity.BaseSerializer`, producing *"identical names, different identities"* warnings. Each now carries a model-suffixed `component_name` (`CompanyEntityBaseSerializer`, `PersonEntityBaseSerializer`, `ContactEntityBaseSerializer`), matching the existing `Model`/`View` serializer naming in these files.

- `python manage.py spectacular --api-version v2` warnings: **71 -> 68** (the three `EntityBaseBase` collisions removed, no new warnings introduced).
- No runtime behaviour change - schema component naming only.
- Deliberately does not touch the feature-locked `itam.*` / `assistance.*` serializers.


### :link: Links / References
<!--

    using a list as any links to other references or links as required. if relevant, describe the link/reference

    Include any issues or related merge requests. Note: dependent MR's also to be added to "Merge request dependencies"

-->

- Part of #361 (scoped per the "one PR per model / group of serializers" approach discussed there).


### :construction_worker: Tasks

- [x] :mag: `spectacular` warnings reduced 71 -> 68, no new warnings introduced
- [x] :test_tube: Existing entity serializer unit tests pass (36 passed, 0 failed) - schema-metadata-only change, no new behaviour to cover

<!-- dont remove tasks below strike through including the checkbox by enclosing in double tidle '~~' -->

 - [ ] ~~**Feature Release ONLY** :red_square: [Squash migration files](https://docs.djangoproject.com/en/5.2/topics/migrations/#squashing-migrations) :red_square:~~
    _Multiple migration files created as part of this release are to be sqauashed into a few files as possible so as to limit the number of migrations_

- [ ] :firecracker: Contains breaking-change Any Breaking change(s)?

    _Breaking Change must also be notated in the commit that introduces it and in [Conventional Commit Format](https://www.conventionalcommits.org/en/v1.0.0/)._

    - [ ] :notebook: Release notes updated

- [ ] :blue_book: Documentation written

    _All features to be documented within the correct section(s). Administration, Development and/or User_

- [x] :checkered_flag: Milestone assigned

- [ ] :gear: :test_tube: [Functional Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

- [ ] :test_tube: [Unit Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

    _ensure test coverage delta is not less than zero_

- [ ] :page_facing_up: Roadmap updated
