### PR TITLE
fix(core): Correct ModelTicket QS Filtering

### DIFF
--- a/app/core/tests/unit/model_tickets/test_unit_model_tickets_viewset.py
+++ b/app/core/tests/unit/model_tickets/test_unit_model_tickets_viewset.py
@@ -23,7 +23,14 @@ class ViewsetTestCases(
 
     @pytest.fixture( scope = 'function' )
     def viewset(self):
-        return ViewSet
+
+        viewset = ViewSet
+
+        viewset.kwargs = {'model_id': 1}
+
+        yield ViewSet
+
+        del viewset
 
 
     @property
@@ -129,4 +136,205 @@ class ModelTicketViewsetInheritedCases(
 class ModelTicketViewsetPyTest(
     ViewsetTestCases,
 ):
-    pass
+
+
+    @pytest.mark.xfail( reason = 'Model requires kwarg model_id' )
+    def test_function_get_queryset_manager_calls_user(self, mocker, model, viewset):
+
+        manager = mocker.patch.object(model, 'objects' )
+
+        view_set = viewset()
+        view_set.request = mocker.Mock()
+        view_set.kwargs =  {}
+
+        if model._is_submodel:
+            view_set.kwargs =  {
+                view_set.model_kwarg: model._meta.model_name
+            }
+
+        view_set.get_queryset()
+
+        manager.user.assert_called()
+
+
+
+    def test_function_get_queryset_manager_calls_user_custom_kwarg_model_id(
+        self, mocker, model, viewset
+    ):
+        """Test class function
+
+        Ensure that when function `get_queryset` the manager is first called with
+        `.user()` so as to ensure that the queryset returns only data the user has
+        access to.
+        """
+
+        manager = mocker.patch.object(model, 'objects' )
+
+        view_set = viewset()
+        view_set.request = mocker.Mock()
+        view_set.kwargs =  {
+            'model_id': 1
+        }
+
+        view_set.get_queryset()
+
+        manager.user.assert_called()
+
+
+
+    @pytest.mark.xfail( reason = 'Model requires kwarg model_id' )
+    def test_function_get_queryset_manager_filters_by_pk(self, mocker, model, viewset):
+
+        manager = mocker.patch.object(model, 'objects' )
+
+        view_set = viewset()
+
+        view_set.request = mocker.Mock()
+
+        view_set.kwargs =  {
+            'pk': 1
+        }
+
+        view_set.get_queryset()
+
+        manager.user.return_value.all.return_value.filter.assert_called_once_with(pk=1)
+
+
+
+    def test_function_get_queryset_manager_filters_by_pk_custom_kwarg_model_id(
+        self, mocker, model, viewset
+    ):
+        """Test class function
+
+        Ensure that when function `get_queryset` the queryset is filtered by `pk` kwarg
+        """
+
+        manager = mocker.patch.object(model, 'objects' )
+
+        view_set = viewset()
+
+        view_set.request = mocker.Mock()
+
+        view_set.kwargs =  {
+            'pk': 1,
+            'model_id': 1
+        }
+
+        view_set.get_queryset()
+
+        manager.user.return_value.all.return_value.filter.assert_called_once_with(pk=1)
+
+
+
+    @pytest.mark.xfail( reason = 'Model requires kwarg model_id' )
+    def test_view_func_get_queryset_cache_result(self, mocker, viewset_mock_request):
+
+        view_set = viewset_mock_request
+        view_set.kwargs = {
+            'model_id': 1
+        }
+        mocker.patch.object(view_set.model, 'objects', return_value = 'boo')
+
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as queries:
+
+            assert view_set._queryset is None    # Must be empty before init
+
+            view_set.get_queryset()
+
+            initial_db_queries = len(queries)
+
+            assert view_set._queryset is not None    # Must not be empty after init
+
+            assert len(queries) == initial_db_queries
+
+
+
+    def test_view_func_get_queryset_cache_result_custom_kwarg_model_id(
+        self, mocker, viewset_mock_request
+    ):
+        """Viewset Test
+
+        Ensure that the `get_queryset` function caches the result under
+        attribute `<viewset>._queryset`
+        """
+
+        view_set = viewset_mock_request
+        view_set.kwargs = {
+            'model_id': 1
+        }
+        mocker.patch.object(view_set.model, 'objects', return_value = 'boo')
+
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as queries:
+
+            assert view_set._queryset is None    # Must be empty before init
+
+            view_set.get_queryset()
+
+            initial_db_queries = len(queries)
+
+            assert view_set._queryset is not None    # Must not be empty after init
+
+            assert len(queries) == initial_db_queries
+
+
+
+    @pytest.mark.xfail( reason = 'Model requires kwarg model_id' )
+    def test_view_func_get_queryset_cache_result_used(self, mocker, viewset, viewset_mock_request):
+
+        view_set = viewset_mock_request
+
+        qs = mocker.spy(view_set.model, 'objects')
+
+        view_set.get_queryset()    # Initial QuerySet fetch/filter and cache
+
+        initial_method_calls = len(qs.method_calls)
+        initial_mock_calls = len(qs.mock_calls)
+
+        # one call to .all()
+        assert initial_method_calls > 0
+        # calls = .user( ...), .user().all(), .user().all().filter()
+        assert initial_mock_calls > 0
+
+        view_set.get_queryset()    # Use Cached results, dont re-fetch QuerySet
+
+        assert len(qs.method_calls) == initial_method_calls
+        assert len(qs.mock_calls) == initial_mock_calls
+
+
+
+    def test_view_func_get_queryset_cache_result_used_custom_kwarg_model_id(
+        self, mocker, viewset, viewset_mock_request
+    ):
+        """Viewset Test
+
+        Ensure that the `get_queryset` function caches the result under
+        attribute `<viewset>._queryset`
+        """
+
+        view_set = viewset_mock_request
+        view_set.kwargs = {
+            'model_id': 1
+        }
+
+        qs = mocker.spy(view_set.model, 'objects')
+
+        view_set.get_queryset()    # Initial QuerySet fetch/filter and cache
+
+        initial_method_calls = len(qs.method_calls)
+        initial_mock_calls = len(qs.mock_calls)
+
+        # one call to .all()
+        assert initial_method_calls > 0
+        # calls = .user( ...), .user().all(), .user().all().filter()
+        assert initial_mock_calls > 0
+
+        view_set.get_queryset()    # Use Cached results, dont re-fetch QuerySet
+
+        assert len(qs.method_calls) == initial_method_calls
+        assert len(qs.mock_calls) == initial_mock_calls

--- a/app/core/viewsets/ticket_model_link.py
+++ b/app/core/viewsets/ticket_model_link.py
@@ -186,7 +186,7 @@ class ViewSet( SubModelViewSet_ReWrite ):
             return model
 
         except FieldDoesNotExist:
-            
+
             return None
 
 
@@ -200,13 +200,7 @@ class ViewSet( SubModelViewSet_ReWrite ):
 
             self._queryset = super().get_queryset()
 
-            if 'ticket_id' in self.kwargs:
-
-                self._queryset = self._queryset.filter(
-                    ticket_id = int( self.kwargs['ticket_id'] )
-                )
-
-            elif(
+            if(
                 'app_label' in self.kwargs
                 and 'model_name' in self.kwargs
             ):
@@ -214,6 +208,13 @@ class ViewSet( SubModelViewSet_ReWrite ):
                 self._queryset = self._queryset.filter(
                     model_id = int( self.kwargs[self.parent_model_pk_kwarg] )
                 )
+
+            else:
+
+                self._queryset = self._queryset.filter(
+                    ticket_id = int( self.kwargs['model_id'] )
+                )
+
 
 
         return self._queryset


### PR DESCRIPTION
### :books: Summary
<!-- your summary here emojis ref: https://github.com/yodamad/gitlab-emoji -->

<!--

You may as required add another L3 header here if you need to provide more detail than a summary.

-->




### :link: Links / References
<!-- 

    using a list as any links to other references or links as required. if relevant, describe the link/reference

    Include any issues or related merge requests. Note: dependent MR's also to be added to "Merge request dependencies"

-->

- Related: #1207 

### :construction_worker: Tasks

<!--

Add any tasks you wish to this section. Its intent is for you to be able to keep track of items that need to be done.
Additionally the code reviewer can see and confirm if they are done so as to assist.

-->




<!--

DO NOT EDIT / CHANGE ANYTHING BELOW THIS LINE.

Exception: There has been a policy change and said change should be included below. If this occurs please 
raise an issue to address. Or `/cc` a maintainer to confirm that it's OK to update this template as part
of you pull request.

-->


#### :mag: Code Reviewer Tasks
<!--

The Following tasks are for the code reviewer.

    - Do NOT remove ANY tasks below strike through including the checkbox by enclosing in double tidle '~~'
    
-->

 - [ ] **Feature Release ONLY** :red_square: [Squash migration files](https://docs.djangoproject.com/en/5.2/topics/migrations/#squashing-migrations) :red_square: 
    _Multiple migration files created as part of this release are to be sqauashed into a few files as possible so as to limit the number of migrations_ 

- [ ] :firecracker: Contains breaking-change Any Breaking change(s)?

    _Breaking Change must also be notated in the commit that introduces it and in [Conventional Commit Format](https://www.conventionalcommits.org/en/v1.0.0/)._

    - [ ] :notebook: Release notes updated

- [ ] :blue_book: Documentation written

    _All features to be documented within the correct section(s). Administration, Development and/or User_

- [x] :checkered_flag: Milestone assigned

- [ ] :gear: :test_tube: [Functional Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

- [x] :test_tube: [Unit Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

    _ensure test coverage delta is not less than zero_

- [x] :page_facing_up: Roadmap updated
