### PR TITLE
test(access): Add invalid-input serializer tests for Contact email

### DIFF
--- a/app/access/tests/unit/contact/test_unit_contact_serializer.py
+++ b/app/access/tests/unit/contact/test_unit_contact_serializer.py
@@ -42,6 +42,78 @@ class ContactSerializerTestCases(
             )
 
 
+    def test_serializer_validation_invalid_email(self,
+        kwargs_api_create, model, model_serializer, request_user
+    ):
+        """Serializer Validation Check
+
+        Ensure that supplying an invalidly formatted email address raises a
+        validation error.
+        """
+
+        mock_view = MockView(
+            user = request_user,
+            model = model,
+            action = 'create',
+        )
+
+        kwargs = kwargs_api_create.copy()
+        kwargs['email'] = 'not-an-email'
+
+        with pytest.raises(ValidationError) as err:
+
+            serializer = model_serializer['model'](
+                context = {
+                    'request': mock_view.request,
+                    'view': mock_view,
+                },
+                data = kwargs,
+            )
+
+            serializer.is_valid(raise_exception = True)
+
+        assert err.value.get_codes()['email'][0] == 'invalid'
+
+
+    def test_serializer_validation_duplicate_email(self,
+        kwargs_api_create, model, model_kwargs, model_serializer, request_user
+    ):
+        """Serializer Validation Check
+
+        Ensure that creating a contact with an email that already exists raises
+        a validation error, as the email field is unique.
+        """
+
+        mock_view = MockView(
+            user = request_user,
+            model = model,
+            action = 'create',
+        )
+
+        existing = model.objects.create( **model_kwargs() )
+
+        kwargs = kwargs_api_create.copy()
+        kwargs['email'] = existing.email
+
+        with pytest.raises(ValidationError) as err:
+
+            serializer = model_serializer['model'](
+                context = {
+                    'request': mock_view.request,
+                    'view': mock_view,
+                },
+                data = kwargs,
+            )
+
+            serializer.is_valid(raise_exception = True)
+
+            serializer.save()
+
+        assert err.value.get_codes()['email'][0] == 'unique'
+
+        existing.delete()
+
+
 
 
 class ContactSerializerInheritedCases(


### PR DESCRIPTION
### :books: Summary

Addresses #852 (input-validation regression tests), starting with an `Access.Entity`-based model as suggested by @jon-nfc.

`Contact` (inherits `Person` -> `Entity`) has a unique `email = EmailField(unique=True)`, which gives two clear invalid-input regression tests. Both assert the serializer rejects the bad input at validation time - the failsafe for the class of issue behind #850, where DRF-only validation let invalid input through:

- `test_serializer_validation_invalid_email` - an invalidly formatted address raises a `ValidationError` (code `invalid`).
- `test_serializer_validation_duplicate_email` - a duplicate address raises a `ValidationError` (code `unique`).

Kept clear of the feature-locked `itam.*` / `assistance.*` serializers. Further models/fields (e.g. `Company.clean_fields`) can follow in separate PRs.


### :link: Links / References

- Part of #852
- Regression cover for the class of issue in #850


### :construction_worker: Tasks

- [x] :test_tube: Two invalid-input tests added to `ContactSerializerTestCases`, both passing
- [x] :white_check_mark: Full `test_unit_contact_serializer.py` suite green locally (16 passed, 1 skipped, 1 xfailed) - purely additive, no regressions


<!--

DO NOT EDIT / CHANGE ANYTHING BELOW THIS LINE.

Exception: There has been a policy change and said change should be included below. If this occurs please 
raise an issue to address. Or `/cc` a maintainer to confirm that it's OK to update this template as part
of you pull request.

-->


#### :mag: Code Reviewer Tasks
<!--

The Following tasks are for the code reviewer.

    - Do NOT remove ANY tasks below strike through including the checkbox by enclosing in double tidle '~~'
    
-->

 - [ ] ~~**Feature Release ONLY** :red_square: [Squash migration files](https://docs.djangoproject.com/en/5.2/topics/migrations/#squashing-migrations) :red_square:~~
    _Multiple migration files created as part of this release are to be sqauashed into a few files as possible so as to limit the number of migrations_

- [ ] :firecracker: Contains breaking-change Any Breaking change(s)?

    _Breaking Change must also be notated in the commit that introduces it and in [Conventional Commit Format](https://www.conventionalcommits.org/en/v1.0.0/)._

    - [ ] :notebook: Release notes updated

- [ ] :blue_book: Documentation written

    _All features to be documented within the correct section(s). Administration, Development and/or User_

- [ ] :checkered_flag: Milestone assigned

- [ ] :gear: :test_tube: [Functional Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

- [ ] :test_tube: [Unit Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

    _ensure test coverage delta is not less than zero_

- [ ] :page_facing_up: Roadmap updated
