### PR TITLE
docs(devops): Name the feature flag serializer schema components uniquely

### DIFF
--- a/app/devops/serializers/centurionaudit_featureflag.py
+++ b/app/devops/serializers/centurionaudit_featureflag.py
@@ -14,7 +14,7 @@ from core.serializers.centurionaudit import (
 
 
 
-@extend_schema_serializer(component_name = 'FeatureFlagModelSerializer')
+@extend_schema_serializer(component_name = 'FeatureFlagAuditHistoryModelSerializer')
 class ModelSerializer(
     common.CommonModelSerializer,
     BaseSerializer
@@ -44,7 +44,7 @@ class ModelSerializer(
 
 
 
-@extend_schema_serializer(component_name = 'FeatureFlagViewSerializer')
+@extend_schema_serializer(component_name = 'FeatureFlagAuditHistoryViewSerializer')
 class ViewSerializer(
     ModelSerializer,
     AuditHistoryViewSerializer,

--- a/app/devops/serializers/centurionmodelnote_featureflag.py
+++ b/app/devops/serializers/centurionmodelnote_featureflag.py
@@ -14,7 +14,7 @@ from core.serializers.centurionmodelnote import (    # pylint: disable=W0611:unu
 
 
 
-@extend_schema_serializer(component_name = 'FeatureFlagModelSerializer')
+@extend_schema_serializer(component_name = 'FeatureFlagCenturionModelNoteModelSerializer')
 class ModelSerializer(
     BaseModelModelSerializer,
 ):
@@ -76,7 +76,7 @@ class ModelSerializer(
         return is_valid
 
 
-@extend_schema_serializer(component_name = 'FeatureFlagViewSerializer')
+@extend_schema_serializer(component_name = 'FeatureFlagCenturionModelNoteViewSerializer')
 class ViewSerializer(
     ModelSerializer,
     BaseModelViewSerializer,

--- a/app/devops/serializers/feature_flag.py
+++ b/app/devops/serializers/feature_flag.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from drf_spectacular.utils import extend_schema_serializer
+
 from access.serializers.organization import Organization, TenantBaseSerializer
 
 from api.serializers import common
@@ -37,6 +39,7 @@ class SoftwareField(serializers.PrimaryKeyRelatedField):
 
 
 
+@extend_schema_serializer(component_name = 'FeatureFlagBaseSerializer')
 class BaseSerializer(serializers.ModelSerializer):
 
     display_name = serializers.SerializerMethodField('get_display_name')
@@ -67,6 +70,7 @@ class BaseSerializer(serializers.ModelSerializer):
         ]
 
 
+@extend_schema_serializer(component_name = 'FeatureFlagModelSerializer')
 class ModelSerializer(
     common.CommonModelSerializer,
     BaseSerializer
@@ -160,6 +164,7 @@ class ModelSerializer(
 
 
 
+@extend_schema_serializer(component_name = 'FeatureFlagViewSerializer')
 class ViewSerializer(ModelSerializer):
 
     organization = TenantBaseSerializer( read_only = True )

--- a/app/devops/serializers/public_feature_flag.py
+++ b/app/devops/serializers/public_feature_flag.py
@@ -1,9 +1,12 @@
 from rest_framework import serializers
 
+from drf_spectacular.utils import extend_schema_serializer
+
 from devops.models.feature_flag import FeatureFlag
 
 
 
+@extend_schema_serializer(component_name = 'PublicFeatureFlagViewSerializer')
 class ViewSerializer(
     serializers.ModelSerializer,
 ):

--- a/app/devops/serializers/software_enable_feature_flag.py
+++ b/app/devops/serializers/software_enable_feature_flag.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from drf_spectacular.utils import extend_schema_serializer
+
 from access.serializers.organization import TenantBaseSerializer
 
 from api.serializers import common
@@ -10,6 +12,7 @@ from itam.serializers.software import SoftwareBaseSerializer
 
 
 
+@extend_schema_serializer(component_name = 'SoftwareEnableFeatureFlagBaseSerializer')
 class BaseSerializer(serializers.ModelSerializer):
 
     display_name = serializers.SerializerMethodField('get_display_name')
@@ -40,6 +43,7 @@ class BaseSerializer(serializers.ModelSerializer):
         ]
 
 
+@extend_schema_serializer(component_name = 'SoftwareEnableFeatureFlagModelSerializer')
 class ModelSerializer(
     common.CommonModelSerializer,
     BaseSerializer
@@ -92,6 +96,7 @@ class ModelSerializer(
 
 
 
+@extend_schema_serializer(component_name = 'SoftwareEnableFeatureFlagViewSerializer')
 class ViewSerializer(ModelSerializer):
 
     organization = TenantBaseSerializer( read_only = True )


### PR DESCRIPTION
### :books: Summary

Continues #361 with the `devops` feature-flag serializers (the Entity group is already merged), prioritising the non-feature-flagged `/feature_flag` routes as you asked.

These serializers resolved to colliding OpenAPI component names:

- `feature_flag`, `public_feature_flag` and `software_enable_feature_flag` shared the generic `View` / `Model` (and the derived `PaginatedViewList`);
- `centurionaudit_featureflag` and `centurionmodelnote_featureflag` both declared `FeatureFlagView` / `FeatureFlagModel`, so they collided with each other.

Each serializer now has an explicit `component_name` following the `<model class name><type>Serializer` convention:

| Serializer file | Model | Names |
| --- | --- | --- |
| `feature_flag.py` | `FeatureFlag` | `FeatureFlagBase/Model/ViewSerializer` |
| `public_feature_flag.py` | `FeatureFlag` (public) | `PublicFeatureFlagViewSerializer` |
| `software_enable_feature_flag.py` | `SoftwareEnableFeatureFlag` | `SoftwareEnableFeatureFlagBase/Model/ViewSerializer` |
| `centurionaudit_featureflag.py` | `FeatureFlagAuditHistory` | `FeatureFlagAuditHistoryModel/ViewSerializer` |
| `centurionmodelnote_featureflag.py` | `FeatureFlagCenturionModelNote` | `FeatureFlagCenturionModelNoteModel/ViewSerializer` |

`python manage.py spectacular --api-version v2` warnings drop from **226 to 209** (67 -> 60 unique), with no new collisions.

One naming call I'd like to confirm: `public_feature_flag` serialises `FeatureFlag` too, so I named it `PublicFeatureFlagViewSerializer` to keep it distinct from the main one - happy to change if you'd prefer something else.

The Git-repository serializers (behind the `2025-00001` flag) are left for a follow-up PR.


### :link: Links / References

- Part of #361


### :construction_worker: Tasks

- [x] :mag: `spectacular` warnings reduced (226 -> 209), no new collisions
- [x] :test_tube: `devops` feature-flag serializer tests pass locally (schema-metadata-only change; no test references the old component names)


<!--

DO NOT EDIT / CHANGE ANYTHING BELOW THIS LINE.

Exception: There has been a policy change and said change should be included below. If this occurs please 
raise an issue to address. Or `/cc` a maintainer to confirm that it's OK to update this template as part
of you pull request.

-->


#### :mag: Code Reviewer Tasks
<!--

The Following tasks are for the code reviewer.

    - Do NOT remove ANY tasks below strike through including the checkbox by enclosing in double tidle '~~'
    
-->

 - [ ] ~~**Feature Release ONLY** :red_square: [Squash migration files](https://docs.djangoproject.com/en/5.2/topics/migrations/#squashing-migrations) :red_square:~~
    _Multiple migration files created as part of this release are to be sqauashed into a few files as possible so as to limit the number of migrations_

- [ ] :firecracker: Contains breaking-change Any Breaking change(s)?

    _Breaking Change must also be notated in the commit that introduces it and in [Conventional Commit Format](https://www.conventionalcommits.org/en/v1.0.0/)._

    - [ ] :notebook: Release notes updated

- [ ] :blue_book: Documentation written

    _All features to be documented within the correct section(s). Administration, Development and/or User_

- [x] :checkered_flag: Milestone assigned

- [ ] :gear: :test_tube: [Functional Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

- [ ] :test_tube: [Unit Test(s) Written](https://nofusscomputing.com/projects/centurion_erp/development/testing/)

    _ensure test coverage delta is not less than zero_

- [ ] :page_facing_up: Roadmap updated
